### PR TITLE
feat: add custom field to procedures table

### DIFF
--- a/app/controllers/api/v1/procedures_controller.rb
+++ b/app/controllers/api/v1/procedures_controller.rb
@@ -53,7 +53,7 @@ module Api
       end
 
       def procedure_params
-        params.permit(:name, :code, :amount_cents).to_h
+        params.permit(:name, :code, :amount_cents, :custom).to_h
       end
     end
   end

--- a/app/controllers/api/v1/procedures_controller.rb
+++ b/app/controllers/api/v1/procedures_controller.rb
@@ -15,7 +15,7 @@ module Api
 
       def create
         authorize(Procedure)
-        result = Procedures::Create.result(attributes: procedure_params)
+        result = Procedures::Create.result(attributes: procedure_params, user: current_user)
 
         if result.success?
           render json: result.procedure, status: :created

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -3,6 +3,8 @@
 class Procedure < ApplicationRecord
   monetize :amount
 
+  belongs_to :user, optional: true
+
   has_many :event_procedures, dependent: :destroy
 
   validates :name, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,7 @@ class User < ApplicationRecord
   has_many :event_procedures, dependent: :destroy
   has_many :medical_shifts, dependent: :destroy
   has_many :patients, dependent: :destroy
+  has_many :procedures, dependent: :destroy
 
   validates :email, uniqueness: { case_sensitive: false }
 end

--- a/app/operations/procedures/create.rb
+++ b/app/operations/procedures/create.rb
@@ -3,11 +3,13 @@
 module Procedures
   class Create < Actor
     input :attributes, type: Hash
+    input :user, type: User, default: nil
 
     output :procedure, type: Procedure
 
     def call
       self.procedure = Procedure.new(attributes)
+      procedure.user = user if procedure.custom?
 
       fail!(error: :invalid_record) unless procedure.save
     end

--- a/app/serializers/procedure_serializer.rb
+++ b/app/serializers/procedure_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ProcedureSerializer < ActiveModel::Serializer
-  attributes :id, :name, :code, :description, :amount_cents
+  attributes :id, :name, :code, :description, :amount_cents, :custom, :user_id
 
   def amount_cents
     object.amount.format

--- a/db/migrate/20240319125612_add_custom_to_procedures.rb
+++ b/db/migrate/20240319125612_add_custom_to_procedures.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddCustomToProcedures < ActiveRecord::Migration[7.0]
+  def change
+    add_column :procedures, :custom, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20240319131254_add_user_id_to_procedures.rb
+++ b/db/migrate/20240319131254_add_user_id_to_procedures.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddUserIdToProcedures < ActiveRecord::Migration[7.0]
+  def change
+    add_column :procedures, :user_id, :integer
+    add_index :procedures, :user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_19_125612) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_19_131254) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -99,7 +99,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_19_125612) do
     t.integer "amount_cents", default: 0, null: false
     t.text "description"
     t.boolean "custom", default: false, null: false
+    t.integer "user_id"
     t.index ["code"], name: "index_procedures_on_code", unique: true
+    t.index ["user_id"], name: "index_procedures_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_19_112216) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_19_125612) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -98,6 +98,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_19_112216) do
     t.datetime "updated_at", null: false
     t.integer "amount_cents", default: 0, null: false
     t.text "description"
+    t.boolean "custom", default: false, null: false
     t.index ["code"], name: "index_procedures_on_code", unique: true
   end
 

--- a/spec/factories/procedures.rb
+++ b/spec/factories/procedures.rb
@@ -6,5 +6,6 @@ FactoryBot.define do
     sequence(:code) { |n| "code#{n}" }
     amount_cents { 1 }
     description { "Procedure description" }
+    custom { false }
   end
 end

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -4,6 +4,8 @@ require "rails_helper"
 
 RSpec.describe Procedure do
   describe "associations" do
+    it { is_expected.to belong_to(:user).optional(true) }
+
     it { is_expected.to have_many(:event_procedures).dependent(:destroy) }
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe User do
     it { is_expected.to have_many(:event_procedures).dependent(:destroy) }
     it { is_expected.to have_many(:medical_shifts).dependent(:destroy) }
     it { is_expected.to have_many(:patients).dependent(:destroy) }
+    it { is_expected.to have_many(:procedures).dependent(:destroy) }
   end
 
   describe "validations" do

--- a/spec/operations/procedures/create_spec.rb
+++ b/spec/operations/procedures/create_spec.rb
@@ -5,17 +5,17 @@ require "rails_helper"
 RSpec.describe Procedures::Create, type: :operation do
   describe ".result" do
     context "when params are valid" do
-      let!(:attributes) do
-        { name: "Test Procedure", code: "03.02.04.01-5", amount_cents: 1000 }
-      end
-
       it "is successful" do
+        attributes = { name: "Procedure 1", code: "PROC1", amount_cents: 1000, custom: false }
+
         result = described_class.result(attributes: attributes)
 
         expect(result).to be_success
       end
 
       it "creates a procedure" do
+        attributes = { name: "Procedure 1", code: "PROC1", amount_cents: 1000, custom: false }
+
         result = described_class.result(attributes: attributes)
 
         expect(result.procedure).to be_persisted
@@ -26,24 +26,50 @@ RSpec.describe Procedures::Create, type: :operation do
           amount_cents: attributes[:amount_cents]
         )
       end
+
+      context "when custom attribute is true" do
+        it "associates the current user" do
+          user = create(:user)
+          attributes = { name: "Procedure 1", code: "PROC1", amount_cents: 1000, custom: true }
+
+          result = described_class.result(attributes: attributes, user: user)
+
+          expect(result.procedure.user).to eq(user)
+        end
+      end
+
+      context "when custom attribute is false" do
+        it "does not associate the current user" do
+          user = create(:user)
+          attributes = { name: "Procedure 1", code: "PROC1", amount_cents: 1000, custom: false }
+
+          result = described_class.result(attributes: attributes, user: user)
+
+          expect(result.procedure.user).to be_nil
+        end
+      end
     end
 
     context "when params are invalid" do
-      let!(:invalid_attributes) { { name: nil, code: nil } }
-
       it "is failure" do
+        invalid_attributes = { name: nil, code: nil }
+
         result = described_class.result(attributes: invalid_attributes)
 
         expect(result).to be_failure
       end
 
       it "returns a invalid procedure" do
+        invalid_attributes = { name: nil, code: nil }
+
         result = described_class.result(attributes: invalid_attributes)
 
         expect(result.procedure).not_to be_valid
       end
 
       it "returns error messages" do
+        invalid_attributes = { name: nil, code: nil }
+
         result = described_class.result(attributes: invalid_attributes)
 
         expect(result.procedure.errors.full_messages).to eq(["Name can't be blank", "Code can't be blank"])


### PR DESCRIPTION
fix: #129 
- add `custom` field to `procedures` table.
- add `User` to `Procedures` and associate `user` with `procedure` when `custom` attribute is true.