### PR TITLE
refactor: remove the mandatory presence of the room_type and urgency columns in the event_procedures table

### DIFF
--- a/app/models/event_procedure.rb
+++ b/app/models/event_procedure.rb
@@ -20,6 +20,7 @@ class EventProcedure < ApplicationRecord
 
   validates :date, presence: true
   validates :patient_service_number, presence: true
-  validates :room_type, presence: true
+  validates :room_type, presence: true, if: -> { health_insurance? }
+  validates :urgency, inclusion: [true, false], if: -> { health_insurance? }
   validates :payment, presence: true
 end

--- a/db/migrate/20240329122823_change_room_type_and_urgency_in_event_procedures.rb
+++ b/db/migrate/20240329122823_change_room_type_and_urgency_in_event_procedures.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ChangeRoomTypeAndUrgencyInEventProcedures < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :event_procedures, :room_type, true
+    change_column_null :event_procedures, :urgency, true
+    change_column_default :event_procedures, :urgency, from: false, to: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_25_123343) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_29_122823) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -38,8 +38,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_25_123343) do
     t.bigint "health_insurance_id", null: false
     t.string "patient_service_number", null: false
     t.datetime "date", null: false
-    t.boolean "urgency", default: false, null: false
-    t.string "room_type", null: false
+    t.boolean "urgency"
+    t.string "room_type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "total_amount_cents"

--- a/spec/operations/event_procedures/create_spec.rb
+++ b/spec/operations/event_procedures/create_spec.rb
@@ -104,7 +104,8 @@ RSpec.describe EventProcedures::Create, type: :operation do
             "Procedure must exist",
             "Date can't be blank",
             "Patient service number can't be blank",
-            "Room type can't be blank"
+            "Room type can't be blank",
+            "Urgency is not included in the list"
           ]
         )
       end

--- a/spec/requests/api/v1/event_procedures_request_spec.rb
+++ b/spec/requests/api/v1/event_procedures_request_spec.rb
@@ -231,7 +231,8 @@ RSpec.describe "EventProcedures" do
               "procedure" => ["must exist"],
               "date" => ["can't be blank"],
               "patient_service_number" => ["can't be blank"],
-              "room_type" => ["can't be blank"]
+              "room_type" => ["can't be blank"],
+              "urgency" => ["is not included in the list"]
             )
           end
         end


### PR DESCRIPTION
fix: #144 