### PR TITLE
refactor: endpoint to return only health_insurances with the attribute custon=false by default

### DIFF
--- a/app/controllers/api/v1/health_insurances_controller.rb
+++ b/app/controllers/api/v1/health_insurances_controller.rb
@@ -5,7 +5,8 @@ module Api
     class HealthInsurancesController < ApiController
       def index
         health_insurances = HealthInsurances::List.result(
-          params: params.permit(:page, :per_page).to_h
+          params: params.permit(:page, :per_page, :custom).to_h,
+          user: current_user
         ).health_insurances
         authorize(health_insurances)
 

--- a/app/models/health_insurance.rb
+++ b/app/models/health_insurance.rb
@@ -5,6 +5,8 @@ class HealthInsurance < ApplicationRecord
 
   has_many :event_procedures, dependent: :destroy
 
+  scope :by_custom, HealthInsurances::ByCustomQuery
+
   validates :name, presence: true
   validates :user_id, presence: true, if: :custom?
 

--- a/app/operations/health_insurances/list.rb
+++ b/app/operations/health_insurances/list.rb
@@ -4,11 +4,27 @@ module HealthInsurances
   class List < Actor
     input :scope, type: Enumerable, default: -> { HealthInsurance.all }
     input :params, type: Hash, default: -> { {} }
+    input :user, type: User, default: nil
 
     output :health_insurances, type: Enumerable
 
     def call
-      self.health_insurances = scope.order(created_at: :desc).page(params[:page]).per(params[:per_page])
+      self.health_insurances = filtered_query.order(created_at: :desc).page(params[:page]).per(params[:per_page])
+    end
+
+    private
+
+    def filtered_query
+      query = scope
+      apply_custom_filter(query)
+    end
+
+    def apply_custom_filter(query)
+      if %w[true false].include?(params[:custom])
+        query.by_custom(custom: params[:custom], user: user)
+      else
+        query.where(custom: false)
+      end
     end
   end
 end

--- a/app/queries/health_insurances/by_custom_query.rb
+++ b/app/queries/health_insurances/by_custom_query.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module HealthInsurances
+  class ByCustomQuery < ApplicationQuery
+    attr_reader :custom, :user, :relation
+
+    def initialize(custom:, user:, relation: HealthInsurance)
+      @custom = custom
+      @user = user
+      @relation = relation
+    end
+
+    def call
+      custom == "true" ? relation.where(custom: true, user: user) : relation.where(custom: false)
+    end
+  end
+end

--- a/spec/operations/health_insurances/list_spec.rb
+++ b/spec/operations/health_insurances/list_spec.rb
@@ -25,6 +25,32 @@ RSpec.describe HealthInsurances::List, type: :operation do
         ]
       )
     end
+
+    context "when custom is true" do
+      it "returns only the custom health_insurances for the given user" do
+        user = create(:user)
+        another_user = create(:user)
+        custom_health_insurance = create(:health_insurance, custom: true, user: user)
+        _another_custom_health_insurance = create(:health_insurance, custom: true, user: another_user)
+        _non_custom_health_insurance = create(:health_insurance, custom: false)
+
+        result = described_class.result(params: { custom: "true" }, user: user)
+
+        expect(result.health_insurances).to contain_exactly(custom_health_insurance)
+      end
+    end
+
+    context "when custom is false" do
+      it "returns only the non-custom health_insurances" do
+        user = create(:user)
+        _custom_health_insurance = create(:health_insurance, custom: true, user: user)
+        non_custom_health_insurance = create(:health_insurance, custom: false)
+
+        result = described_class.result(params: { custom: "false" }, user: user)
+
+        expect(result.health_insurances).to contain_exactly(non_custom_health_insurance)
+      end
+    end
   end
 
   context "when has pagination via page and per_page" do

--- a/spec/queries/health_insurances/by_custom_query_spec.rb
+++ b/spec/queries/health_insurances/by_custom_query_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe HealthInsurances::ByCustomQuery do
+  context "when custom is true" do
+    it "returns only custom health_insurances for the given user" do
+      user = create(:user)
+      another_user = create(:user)
+      custom_health_insurance = create(:health_insurance, custom: true, user: user)
+      _another_custom_health_insurance = create(:health_insurance, custom: true, user: another_user)
+      _non_custom_health_insurance = create(:health_insurance, custom: false)
+
+      by_custom_query = described_class.call(custom: "true", user: user)
+
+      expect(by_custom_query).to contain_exactly(custom_health_insurance)
+    end
+  end
+
+  context "when custom is false" do
+    it "returns only non-custom health_insurances" do
+      user = create(:user)
+      _custom_health_insurance = create(:health_insurance, custom: true, user: user)
+      health_insurance = create(:health_insurance, custom: false)
+
+      by_custom_query = described_class.call(custom: "false", user: user)
+
+      expect(by_custom_query).to contain_exactly(health_insurance)
+    end
+  end
+end


### PR DESCRIPTION
fix: #132 