### PR TITLE
Add standard pattern to delete endpoints

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -4,6 +4,8 @@ module Api
   module V1
     class ApiController < ActionController::API
       include Pundit::Authorization
+      include Respondable
+
       after_action :verify_authorized
 
       before_action :authenticate_devise_api_token!

--- a/app/controllers/api/v1/event_procedures_controller.rb
+++ b/app/controllers/api/v1/event_procedures_controller.rb
@@ -51,7 +51,7 @@ module Api
         result = EventProcedures::Destroy.result(id: event_procedure.id.to_s)
 
         if result.success?
-          render json: result.event_procedure, status: :ok
+          deleted_successfully_render(result.event_procedure)
         else
           render json: result.error, status: :unprocessable_entity
         end

--- a/app/controllers/api/v1/hospitals_controller.rb
+++ b/app/controllers/api/v1/hospitals_controller.rb
@@ -39,7 +39,7 @@ module Api
         result = Hospitals::Destroy.result(id: hospital.id.to_s)
 
         if result.success?
-          render json: result.hospital, status: :ok
+          deleted_successfully_render(result.hospital)
         else
           render json: result.error, status: :unprocessable_entity
         end

--- a/app/controllers/api/v1/patients_controller.rb
+++ b/app/controllers/api/v1/patients_controller.rb
@@ -43,7 +43,7 @@ module Api
         result = Patients::Destroy.result(id: patient.id.to_s)
 
         if result.success?
-          render json: result.patient, status: :ok
+          deleted_successfully_render(result.patient)
         else
           render json: result.error, status: :unprocessable_entity
         end

--- a/app/controllers/api/v1/procedures_controller.rb
+++ b/app/controllers/api/v1/procedures_controller.rb
@@ -41,7 +41,7 @@ module Api
         result = Procedures::Destroy.result(id: procedure.id.to_s)
 
         if result.success?
-          render json: result.procedure, status: :ok
+          deleted_successfully_render(result.procedure)
         else
           render json: result.error, status: :unprocessable_entity
         end

--- a/app/controllers/concerns/respondable.rb
+++ b/app/controllers/concerns/respondable.rb
@@ -4,6 +4,6 @@ module Respondable
   extend ActiveSupport::Concern
 
   def deleted_successfully_render(record)
-    render json: { message: "#{record.class} deleted successfully." }, status: :ok
+    render json: { message: I18n.t("controllers.actions.delete.success", class_name: record.class) }, status: :ok
   end
 end

--- a/app/controllers/concerns/respondable.rb
+++ b/app/controllers/concerns/respondable.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Respondable
+  extend ActiveSupport::Concern
+
+  def deleted_successfully_render(record)
+    render json: { message: "#{record.class} deleted successfully." }, status: :ok
+  end
+end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -8,7 +8,7 @@ class ApplicationPolicy
     @record = record
   end
 
-  def is_user_owner?
+  def user_owner?
     user.present? && user == record.user
   end
 

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -8,8 +8,8 @@ class ApplicationPolicy
     @record = record
   end
 
-  def owner?
-    user == record.user
+  def is_user_owner?
+    user.present? && user == record.user
   end
 
   def index?

--- a/app/policies/event_procedure_policy.rb
+++ b/app/policies/event_procedure_policy.rb
@@ -13,10 +13,10 @@ class EventProcedurePolicy < ApplicationPolicy
   end
 
   def update?
-    is_user_owner?
+    user_owner?
   end
 
   def destroy?
-    is_user_owner?
+    user_owner?
   end
 end

--- a/app/policies/event_procedure_policy.rb
+++ b/app/policies/event_procedure_policy.rb
@@ -13,10 +13,10 @@ class EventProcedurePolicy < ApplicationPolicy
   end
 
   def update?
-    user.present? && owner?
+    is_user_owner?
   end
 
   def destroy?
-    update?
+    is_user_owner?
   end
 end

--- a/app/policies/medical_shift_policy.rb
+++ b/app/policies/medical_shift_policy.rb
@@ -13,6 +13,6 @@ class MedicalShiftPolicy < ApplicationPolicy
   end
 
   def update?
-    is_user_owner?
+    user_owner?
   end
 end

--- a/app/policies/medical_shift_policy.rb
+++ b/app/policies/medical_shift_policy.rb
@@ -13,6 +13,6 @@ class MedicalShiftPolicy < ApplicationPolicy
   end
 
   def update?
-    user.present? && record.user == user
+    is_user_owner?
   end
 end

--- a/app/policies/patient_policy.rb
+++ b/app/policies/patient_policy.rb
@@ -13,10 +13,10 @@ class PatientPolicy < ApplicationPolicy
   end
 
   def update?
-    user.present?
+    user.present? && owner?
   end
 
   def destroy?
-    user.present?
+    update?
   end
 end

--- a/app/policies/patient_policy.rb
+++ b/app/policies/patient_policy.rb
@@ -13,10 +13,10 @@ class PatientPolicy < ApplicationPolicy
   end
 
   def update?
-    is_user_owner?
+    user_owner?
   end
 
   def destroy?
-    is_user_owner?
+    user_owner?
   end
 end

--- a/app/policies/patient_policy.rb
+++ b/app/policies/patient_policy.rb
@@ -13,10 +13,10 @@ class PatientPolicy < ApplicationPolicy
   end
 
   def update?
-    user.present? && owner?
+    is_user_owner?
   end
 
   def destroy?
-    update?
+    is_user_owner?
   end
 end

--- a/app/policies/procedure_policy.rb
+++ b/app/policies/procedure_policy.rb
@@ -10,10 +10,10 @@ class ProcedurePolicy < ApplicationPolicy
   end
 
   def update?
-    user.present? && owner?
+    is_user_owner?
   end
 
   def destroy?
-    update?
+    is_user_owner?
   end
 end

--- a/app/policies/procedure_policy.rb
+++ b/app/policies/procedure_policy.rb
@@ -10,10 +10,10 @@ class ProcedurePolicy < ApplicationPolicy
   end
 
   def update?
-    user.present?
+    user.present? && owner?
   end
 
   def destroy?
-    user.present?
+    update?
   end
 end

--- a/app/policies/procedure_policy.rb
+++ b/app/policies/procedure_policy.rb
@@ -10,10 +10,10 @@ class ProcedurePolicy < ApplicationPolicy
   end
 
   def update?
-    is_user_owner?
+    user_owner?
   end
 
   def destroy?
-    is_user_owner?
+    user_owner?
   end
 end

--- a/config/locales/api/v1/en.yml
+++ b/config/locales/api/v1/en.yml
@@ -1,0 +1,6 @@
+en:
+  controllers:
+    actions:
+      delete:
+        success: "%{class_name} deleted successfully."
+

--- a/spec/policies/application_policy_spec.rb
+++ b/spec/policies/application_policy_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe ApplicationPolicy do
   let(:user) { create(:user) }
   let(:patient) { create(:patient, user: user) }
-  let(:patient_without_user) { create(:patient) }
+  let(:another_owner_patient) { create(:patient) }
 
   permissions :index?, :show?, :create?, :new?, :update?, :edit?, :destroy? do
     it { expect(described_class).not_to permit(nil, nil) }
@@ -17,7 +17,7 @@ RSpec.describe ApplicationPolicy do
     end
 
     context "when user is not owner" do
-      it { expect(described_class).not_to permit(user, patient_without_user) }
+      it { expect(described_class).not_to permit(user, another_owner_patient) }
     end
 
     context "when has no user" do

--- a/spec/policies/application_policy_spec.rb
+++ b/spec/policies/application_policy_spec.rb
@@ -3,57 +3,33 @@
 require "rails_helper"
 
 RSpec.describe ApplicationPolicy do
-  describe "#owner?" do
-    context "when user is the owner of the record" do
-      it "returns true" do
-        user = create(:user)
-        record = create(:medical_shift, user: user)
+  let(:user) { create(:user) }
+  let(:patient) { create(:patient, user: user) }
+  let(:patient_without_user) { create(:patient) }
 
-        expect(described_class.new(user, record).owner?).to be true
-      end
+  permissions :index?, :show?, :create?, :new?, :update?, :edit?, :destroy? do
+    it { expect(described_class).not_to permit(nil, nil) }
+  end
+
+  permissions :is_user_owner? do
+    context "when user is owner" do
+      it { expect(described_class).to permit(user, patient) }
     end
 
-    context "when user is not the owner of the record" do
-      it "returns false" do
-        another_user = create(:user)
-        record = create(:medical_shift, user: create(:user))
+    context "when user is not owner" do
+      it { expect(described_class).not_to permit(user, patient_without_user) }
+    end
 
-        expect(described_class.new(another_user, record).owner?).to be false
-      end
+    context "when has no user" do
+      it { expect(described_class).not_to permit(nil, patient) }
     end
   end
 
-  it "returns false for #index?" do
-    expect(described_class.new(nil, nil).index?).to be false
-  end
+  describe ApplicationPolicy::ApplicationScope do
+    subject(:result) { described_class.new(nil, nil).resolve }
 
-  it "returns false for #show?" do
-    expect(described_class.new(nil, nil).show?).to be false
-  end
-
-  it "returns false for #create?" do
-    expect(described_class.new(nil, nil).create?).to be false
-  end
-
-  it "returns false for #new?" do
-    expect(described_class.new(nil, nil).new?).to be false
-  end
-
-  it "returns false for #update?" do
-    expect(described_class.new(nil, nil).update?).to be false
-  end
-
-  it "returns false for #edit?" do
-    expect(described_class.new(nil, nil).edit?).to be false
-  end
-
-  it "returns false for #destroy?" do
-    expect(described_class.new(nil, nil).destroy?).to be false
-  end
-
-  context "when #resolve is not defined" do
-    it "raises NotImplementedError" do
-      expect { described_class::ApplicationScope.new(nil, nil).resolve }.to raise_error(NotImplementedError)
+    context "when raises error NotImplementedErro" do
+      it { expect { result }.to raise_error(NotImplementedError) }
     end
   end
 end

--- a/spec/policies/application_policy_spec.rb
+++ b/spec/policies/application_policy_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ApplicationPolicy do
     it { expect(described_class).not_to permit(nil, nil) }
   end
 
-  permissions :is_user_owner? do
+  permissions :user_owner? do
     context "when user is owner" do
       it { expect(described_class).to permit(user, patient) }
     end

--- a/spec/policies/event_procedure_dashboard_policy_spec.rb
+++ b/spec/policies/event_procedure_dashboard_policy_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe EventProcedureDashboardPolicy do
+  let(:user) { create(:user) }
+  let(:admin) { create(:user, admin: true) }
+  let(:event_procedure) { create(:event_procedure) }
+
+  describe "#amount_by_day?" do
+    context "when user is admin" do
+      it { expect(described_class.new(admin, event_procedure).amount_by_day?).to be true }
+    end
+
+    context "when user it not admin" do
+      it { expect(described_class.new(user, event_procedure).amount_by_day?).to be false }
+    end
+  end
+end

--- a/spec/policies/event_procedure_dashboard_policy_spec.rb
+++ b/spec/policies/event_procedure_dashboard_policy_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe EventProcedureDashboardPolicy do
   let(:admin) { create(:user, admin: true) }
   let(:event_procedure) { create(:event_procedure) }
 
-  describe "#amount_by_day?" do
+  permissions :amount_by_day? do
     context "when user is admin" do
-      it { expect(described_class.new(admin, event_procedure).amount_by_day?).to be true }
+      it { expect(described_class).to permit(admin, event_procedure) }
     end
 
-    context "when user it not admin" do
-      it { expect(described_class.new(user, event_procedure).amount_by_day?).to be false }
+    context "when user is not admin" do
+      it { expect(described_class).not_to permit(user, event_procedure) }
     end
   end
 end

--- a/spec/policies/event_procedure_policy_spec.rb
+++ b/spec/policies/event_procedure_policy_spec.rb
@@ -5,19 +5,31 @@ require "rails_helper"
 RSpec.describe EventProcedurePolicy do
   let(:user) { create(:user) }
   let(:event_procedure) { create(:event_procedure, user: user) }
-  let(:event_procedure_without_user) { create(:event_procedure) }
+  let(:other_user_event_preocedure) { create(:event_procedure) }
 
   describe EventProcedurePolicy::Scope do
     subject(:result) { instance.resolve }
 
     let(:instance) { described_class.new(user, EventProcedure.all) }
 
+    before do
+      event_procedure
+      other_user_event_preocedure
+    end
+
     context "when has user" do
       it { expect(result).to eq [event_procedure] }
     end
 
     context "when has no user" do
-      let(:user) { nil }
+      let(:instance) { described_class.new(nil, EventProcedure.all) }
+
+      it { expect(result).to eq [] }
+    end
+
+    context "when user is not owner" do
+      let(:another_user) { create(:user) }
+      let(:instance) { described_class.new(another_user, EventProcedure.all) }
 
       it { expect(result).to eq [] }
     end
@@ -35,7 +47,7 @@ RSpec.describe EventProcedurePolicy do
     end
 
     context "when user is not owner" do
-      it { expect(described_class).not_to permit(user, event_procedure_without_user) }
+      it { expect(described_class).not_to permit(user, other_user_event_preocedure) }
     end
   end
 end

--- a/spec/policies/event_procedure_policy_spec.rb
+++ b/spec/policies/event_procedure_policy_spec.rb
@@ -73,5 +73,12 @@ RSpec.describe EventProcedurePolicy do
 
       expect(described_class.new(nil, event_procedure).destroy?).to be false
     end
+
+    context "when belongs to other user" do
+      let(:user) { create(:user) }
+      let(:event_procedure) { create(:event_procedure) }
+
+      it { expect(described_class.new(user, event_procedure).destroy?).to be false }
+    end
   end
 end

--- a/spec/policies/health_insurance_policy_spec.rb
+++ b/spec/policies/health_insurance_policy_spec.rb
@@ -4,26 +4,15 @@ require "rails_helper"
 
 RSpec.describe HealthInsurancePolicy do
   let(:user) { create(:user) }
-  let(:health_insurance_user) { create(:health_insurance, user: user) }
-  let(:health_insurance_no_user) { create(:health_insurance) }
+  let(:health_insurance) { create(:health_insurance, user: user) }
 
-  describe "#index" do
-    context "when health_insurance has user" do
-      it { expect(described_class.new(user, health_insurance_user).index?).to be true }
+  permissions :index?, :create? do
+    context "when has user" do
+      it { expect(described_class).to permit(user, health_insurance) }
     end
 
-    context "when unregistered user" do
-      it { expect(described_class.new(nil, health_insurance_no_user).index?).to be false }
-    end
-  end
-
-  describe "#create" do
-    context "when health_insurance has user" do
-      it { expect(described_class.new(user, health_insurance_user).create?).to be true }
-    end
-
-    context "when unregistered user" do
-      it { expect(described_class.new(nil, health_insurance_no_user).create?).to be false }
+    context "when has no user" do
+      it { expect(described_class).not_to permit(nil, health_insurance) }
     end
   end
 end

--- a/spec/policies/health_insurance_policy_spec.rb
+++ b/spec/policies/health_insurance_policy_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe HealthInsurancePolicy do
+  let(:user) { create(:user) }
+  let(:health_insurance_user) { create(:health_insurance, user: user) }
+  let(:health_insurance_no_user) { create(:health_insurance) }
+
+  describe "#index" do
+    context "when health_insurance has user" do
+      it { expect(described_class.new(user, health_insurance_user).index?).to be true }
+    end
+
+    context "when unregistered user" do
+      it { expect(described_class.new(nil, health_insurance_no_user).index?).to be false }
+    end
+  end
+
+  describe "#create" do
+    context "when health_insurance has user" do
+      it { expect(described_class.new(user, health_insurance_user).create?).to be true }
+    end
+
+    context "when unregistered user" do
+      it { expect(described_class.new(nil, health_insurance_no_user).create?).to be false }
+    end
+  end
+end

--- a/spec/policies/hospital_policy_spec.rb
+++ b/spec/policies/hospital_policy_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe HospitalPolicy do
+  let(:user) { create(:user) }
+  let(:hospital) { create(:hospital) }
+
+  describe "#index" do
+    context "when hospital has user" do
+      it { expect(described_class.new(user, hospital).index?).to be true }
+    end
+
+    context "when unregistered user" do
+      it { expect(described_class.new(nil, hospital).index?).to be false }
+    end
+  end
+
+  describe "#create" do
+    context "when hospital has user" do
+      it { expect(described_class.new(user, hospital).create?).to be true }
+    end
+
+    context "when unregistered user" do
+      it { expect(described_class.new(nil, hospital).create?).to be false }
+    end
+  end
+
+  describe "#update" do
+    context "when hospital has user" do
+      it { expect(described_class.new(user, hospital).update?).to be true }
+    end
+
+    context "when unregistered user" do
+      it { expect(described_class.new(nil, hospital).update?).to be false }
+    end
+  end
+
+  describe "#delete?" do
+    context "when hospital has user" do
+      it { expect(described_class.new(user, hospital).destroy?).to be true }
+    end
+
+    context "when does not have a user" do
+      it { expect(described_class.new(nil, hospital).destroy?).to be false }
+    end
+  end
+end

--- a/spec/policies/hospital_policy_spec.rb
+++ b/spec/policies/hospital_policy_spec.rb
@@ -6,43 +6,13 @@ RSpec.describe HospitalPolicy do
   let(:user) { create(:user) }
   let(:hospital) { create(:hospital) }
 
-  describe "#index" do
-    context "when hospital has user" do
-      it { expect(described_class.new(user, hospital).index?).to be true }
+  permissions :index?, :create?, :update?, :destroy? do
+    context "when has user" do
+      it { expect(described_class).to permit(user, hospital) }
     end
 
-    context "when unregistered user" do
-      it { expect(described_class.new(nil, hospital).index?).to be false }
-    end
-  end
-
-  describe "#create" do
-    context "when hospital has user" do
-      it { expect(described_class.new(user, hospital).create?).to be true }
-    end
-
-    context "when unregistered user" do
-      it { expect(described_class.new(nil, hospital).create?).to be false }
-    end
-  end
-
-  describe "#update" do
-    context "when hospital has user" do
-      it { expect(described_class.new(user, hospital).update?).to be true }
-    end
-
-    context "when unregistered user" do
-      it { expect(described_class.new(nil, hospital).update?).to be false }
-    end
-  end
-
-  describe "#delete?" do
-    context "when hospital has user" do
-      it { expect(described_class.new(user, hospital).destroy?).to be true }
-    end
-
-    context "when does not have a user" do
-      it { expect(described_class.new(nil, hospital).destroy?).to be false }
+    context "when has no user" do
+      it { expect(described_class).not_to permit(nil, hospital) }
     end
   end
 end

--- a/spec/policies/patient_policy_spec.rb
+++ b/spec/policies/patient_policy_spec.rb
@@ -4,70 +4,38 @@ require "rails_helper"
 
 RSpec.describe PatientPolicy do
   let(:user) { create(:user) }
-  let(:patient_user) { create(:patient, user: user) }
-  let(:patient_no_user) { create(:patient) }
+  let(:patient) { create(:patient, user: user) }
+  let(:patient_without_user) { create(:patient) }
 
-  describe "Scope" do
-    subject(:scope) { instance.resolve }
+  describe PatientPolicy::Scope do
+    subject(:result) { instance.resolve }
 
-    context "when registered user" do
-      let(:instance) { described_class::Scope.new(user, Patient.all) }
+    let(:instance) { described_class.new(user, Patient.all) }
 
-      it { expect(scope).to eq [patient_user] }
+    context "when has user" do
+      it { expect(result).to eq [patient] }
     end
 
-    context "when unregistered user" do
-      let(:instance) { described_class::Scope.new(nil, Patient.all) }
+    context "when has no user" do
+      let(:user) { nil }
 
-      it { expect(scope).to eq [] }
-    end
-  end
-
-  describe "#index" do
-    context "when patient has user" do
-      it { expect(described_class.new(user, patient_user).index?).to be true }
-    end
-
-    context "when unregistered user" do
-      it { expect(described_class.new(nil, patient_no_user).index?).to be false }
+      it { expect(result).to eq [] }
     end
   end
 
-  describe "#create" do
-    context "when patient has user" do
-      it { expect(described_class.new(user, patient_user).create?).to be true }
-    end
-
-    context "when unregistered user" do
-      it { expect(described_class.new(nil, patient_no_user).create?).to be false }
+  permissions :index?, :create? do
+    context "when has no user" do
+      it { expect(described_class).not_to permit(nil, patient) }
     end
   end
 
-  describe "#update" do
-    context "when patient has user" do
-      it { expect(described_class.new(user, patient_user).update?).to be true }
+  permissions :update?, :destroy? do
+    context "when user is not owner" do
+      it { expect(described_class).not_to permit(user, patient_without_user) }
     end
 
-    context "when unregistered user" do
-      it { expect(described_class.new(nil, patient_no_user).update?).to be false }
-    end
-
-    context "when belongs to other owner" do
-      it { expect(described_class.new(user, patient_no_user).update?).to be false }
-    end
-  end
-
-  describe "#delete?" do
-    context "when patient has user" do
-      it { expect(described_class.new(user, patient_user).destroy?).to be true }
-    end
-
-    context "when does not have a user" do
-      it { expect(described_class.new(nil, patient_no_user).destroy?).to be false }
-    end
-
-    context "when belongs to other owner" do
-      it { expect(described_class.new(user, patient_no_user).destroy?).to be false }
+    context "when user is owner" do
+      it { expect(described_class).to permit(user, patient) }
     end
   end
 end

--- a/spec/policies/patient_policy_spec.rb
+++ b/spec/policies/patient_policy_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PatientPolicy do
+  let(:user) { create(:user) }
+  let(:patient_user) { create(:patient, user: user) }
+  let(:patient_no_user) { create(:patient) }
+
+  describe "Scope" do
+    subject(:scope) { instance.resolve }
+
+    context "when registered user" do
+      let(:instance) { described_class::Scope.new(user, Patient.all) }
+
+      it { expect(scope).to eq [patient_user] }
+    end
+
+    context "when unregistered user" do
+      let(:instance) { described_class::Scope.new(nil, Patient.all) }
+
+      it { expect(scope).to eq [] }
+    end
+  end
+
+  describe "#index" do
+    context "when patient has user" do
+      it { expect(described_class.new(user, patient_user).index?).to be true }
+    end
+
+    context "when unregistered user" do
+      it { expect(described_class.new(nil, patient_no_user).index?).to be false }
+    end
+  end
+
+  describe "#create" do
+    context "when patient has user" do
+      it { expect(described_class.new(user, patient_user).create?).to be true }
+    end
+
+    context "when unregistered user" do
+      it { expect(described_class.new(nil, patient_no_user).create?).to be false }
+    end
+  end
+
+  describe "#update" do
+    context "when patient has user" do
+      it { expect(described_class.new(user, patient_user).update?).to be true }
+    end
+
+    context "when unregistered user" do
+      it { expect(described_class.new(nil, patient_no_user).update?).to be false }
+    end
+
+    context "when belongs to other owner" do
+      it { expect(described_class.new(user, patient_no_user).update?).to be false }
+    end
+  end
+
+  describe "#delete?" do
+    context "when patient has user" do
+      it { expect(described_class.new(user, patient_user).destroy?).to be true }
+    end
+
+    context "when does not have a user" do
+      it { expect(described_class.new(nil, patient_no_user).destroy?).to be false }
+    end
+
+    context "when belongs to other owner" do
+      it { expect(described_class.new(user, patient_no_user).destroy?).to be false }
+    end
+  end
+end

--- a/spec/policies/patient_policy_spec.rb
+++ b/spec/policies/patient_policy_spec.rb
@@ -5,19 +5,31 @@ require "rails_helper"
 RSpec.describe PatientPolicy do
   let(:user) { create(:user) }
   let(:patient) { create(:patient, user: user) }
-  let(:patient_without_user) { create(:patient) }
+  let(:patient_another_user) { create(:patient) }
 
   describe PatientPolicy::Scope do
     subject(:result) { instance.resolve }
 
     let(:instance) { described_class.new(user, Patient.all) }
 
+    before do
+      patient
+      patient_another_user
+    end
+
     context "when has user" do
       it { expect(result).to eq [patient] }
     end
 
     context "when has no user" do
-      let(:user) { nil }
+      let(:instance) { described_class.new(nil, Patient.all) }
+
+      it { expect(result).to eq [] }
+    end
+
+    context "when user is not owner" do
+      let(:another_user) { create(:user) }
+      let(:instance) { described_class.new(another_user, Patient.all) }
 
       it { expect(result).to eq [] }
     end
@@ -31,7 +43,7 @@ RSpec.describe PatientPolicy do
 
   permissions :update?, :destroy? do
     context "when user is not owner" do
-      it { expect(described_class).not_to permit(user, patient_without_user) }
+      it { expect(described_class).not_to permit(user, patient_another_user) }
     end
 
     context "when user is owner" do

--- a/spec/policies/procedure_policy_spec.rb
+++ b/spec/policies/procedure_policy_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ProcedurePolicy do
+  let(:user) { create(:user) }
+  let(:procedure_user) { create(:procedure, user: user) }
+  let(:procedure_no_user) { create(:procedure) }
+
+  describe "#index" do
+    context "when procedure has user" do
+      it { expect(described_class.new(user, procedure_user).index?).to be true }
+    end
+
+    context "when unregistered user" do
+      it { expect(described_class.new(nil, procedure_no_user).index?).to be false }
+    end
+  end
+
+  describe "#create" do
+    context "when procedure has user" do
+      it { expect(described_class.new(user, procedure_user).create?).to be true }
+    end
+
+    context "when unregistered user" do
+      it { expect(described_class.new(nil, procedure_no_user).create?).to be false }
+    end
+  end
+
+  describe "#update" do
+    context "when procedure has user" do
+      it { expect(described_class.new(user, procedure_user).update?).to be true }
+    end
+
+    context "when unregistered user" do
+      it { expect(described_class.new(nil, procedure_no_user).update?).to be false }
+    end
+
+    context "when belongs to other owner" do
+      it { expect(described_class.new(user, procedure_no_user).update?).to be false }
+    end
+  end
+
+  describe "#delete?" do
+    context "when procedure has user" do
+      it { expect(described_class.new(user, procedure_user).destroy?).to be true }
+    end
+
+    context "when does not have a user" do
+      it { expect(described_class.new(nil, procedure_no_user).destroy?).to be false }
+    end
+
+    context "when belongs to other owner" do
+      it { expect(described_class.new(user, procedure_no_user).destroy?).to be false }
+    end
+  end
+end

--- a/spec/policies/procedure_policy_spec.rb
+++ b/spec/policies/procedure_policy_spec.rb
@@ -4,54 +4,22 @@ require "rails_helper"
 
 RSpec.describe ProcedurePolicy do
   let(:user) { create(:user) }
-  let(:procedure_user) { create(:procedure, user: user) }
-  let(:procedure_no_user) { create(:procedure) }
+  let(:procedure) { create(:procedure, user: user) }
+  let(:procedure_without_user) { create(:procedure) }
 
-  describe "#index" do
-    context "when procedure has user" do
-      it { expect(described_class.new(user, procedure_user).index?).to be true }
-    end
-
-    context "when unregistered user" do
-      it { expect(described_class.new(nil, procedure_no_user).index?).to be false }
+  permissions :index?, :create? do
+    context "when has no user" do
+      it { expect(described_class).not_to permit(nil, procedure) }
     end
   end
 
-  describe "#create" do
-    context "when procedure has user" do
-      it { expect(described_class.new(user, procedure_user).create?).to be true }
+  permissions :update?, :destroy? do
+    context "when user is not owner" do
+      it { expect(described_class).not_to permit(user, procedure_without_user) }
     end
 
-    context "when unregistered user" do
-      it { expect(described_class.new(nil, procedure_no_user).create?).to be false }
-    end
-  end
-
-  describe "#update" do
-    context "when procedure has user" do
-      it { expect(described_class.new(user, procedure_user).update?).to be true }
-    end
-
-    context "when unregistered user" do
-      it { expect(described_class.new(nil, procedure_no_user).update?).to be false }
-    end
-
-    context "when belongs to other owner" do
-      it { expect(described_class.new(user, procedure_no_user).update?).to be false }
-    end
-  end
-
-  describe "#delete?" do
-    context "when procedure has user" do
-      it { expect(described_class.new(user, procedure_user).destroy?).to be true }
-    end
-
-    context "when does not have a user" do
-      it { expect(described_class.new(nil, procedure_no_user).destroy?).to be false }
-    end
-
-    context "when belongs to other owner" do
-      it { expect(described_class.new(user, procedure_no_user).destroy?).to be false }
+    context "when user is owner" do
+      it { expect(described_class).to permit(user, procedure) }
     end
   end
 end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe UserPolicy do
   let(:user) { create(:user) }
   let(:admin) { create(:user, admin: true) }
 
-  describe "#index" do
+  permissions :index? do
     context "when user is admin" do
-      it { expect(described_class.new(admin, user).index?).to be true }
+      it { expect(described_class).to permit(admin, user) }
     end
 
-    context "when user it not admin" do
-      it { expect(described_class.new(user, user).index?).to be false }
+    context "when user is not admin" do
+      it { expect(described_class).not_to permit(user, user) }
     end
   end
 end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UserPolicy do
+  let(:user) { create(:user) }
+  let(:admin) { create(:user, admin: true) }
+
+  describe "#index" do
+    context "when user is admin" do
+      it { expect(described_class.new(admin, user).index?).to be true }
+    end
+
+    context "when user it not admin" do
+      it { expect(described_class.new(user, user).index?).to be false }
+    end
+  end
+end

--- a/spec/requests/api/v1/event_procedures_request_spec.rb
+++ b/spec/requests/api/v1/event_procedures_request_spec.rb
@@ -554,6 +554,7 @@ RSpec.describe "EventProcedures" do
         headers = auth_token_for(user)
         delete "/api/v1/event_procedures/#{event_procedure.id}", headers: headers
 
+        expect(response.parsed_body[:message]).to eq("#{event_procedure.class} deleted successfully.")
         expect(response).to have_http_status(:ok)
       end
 

--- a/spec/requests/api/v1/hospitals_request_spec.rb
+++ b/spec/requests/api/v1/hospitals_request_spec.rb
@@ -190,6 +190,7 @@ RSpec.describe "Hospitals" do
 
         delete "/api/v1/hospitals/#{hospital.id}", headers: headers
 
+        expect(response.parsed_body[:message]).to eq("#{hospital.class} deleted successfully.")
         expect(response).to have_http_status(:ok)
       end
 

--- a/spec/requests/api/v1/patients_request_spec.rb
+++ b/spec/requests/api/v1/patients_request_spec.rb
@@ -200,6 +200,7 @@ RSpec.describe "Patients" do
 
         delete "/api/v1/patients/#{patient.id}", headers: headers
 
+        expect(response.parsed_body[:message]).to eq("#{patient.class} deleted successfully.")
         expect(response).to have_http_status(:ok)
       end
 

--- a/spec/requests/api/v1/patients_request_spec.rb
+++ b/spec/requests/api/v1/patients_request_spec.rb
@@ -141,11 +141,13 @@ RSpec.describe "Patients" do
     end
 
     context "when user is authenticated" do
+      let(:user) { create(:user) }
+
       context "when params are valid" do
-        let!(:patient) { create(:patient, name: "Old Name") }
+        let!(:patient) { create(:patient, user: user, name: "Old Name") }
 
         before do
-          headers = auth_token_for(create(:user))
+          headers = auth_token_for(user)
           put "/api/v1/patients/#{patient.id}", params: { name: "New Name" }, headers: headers
         end
 
@@ -162,10 +164,10 @@ RSpec.describe "Patients" do
       end
 
       context "when params are invalid" do
-        let!(:patient) { create(:patient) }
+        let!(:patient) { create(:patient, user: user) }
 
         before do
-          headers = auth_token_for(create(:user))
+          headers = auth_token_for(user)
           put "/api/v1/patients/#{patient.id}", params: { name: nil }, headers: headers
         end
 
@@ -183,6 +185,8 @@ RSpec.describe "Patients" do
   end
 
   describe "DELETE api/v1/patients/:id" do
+    let(:user) { create(:user) }
+
     context "when user is not authenticated" do
       let!(:patient) { create(:patient) }
 
@@ -195,8 +199,8 @@ RSpec.describe "Patients" do
 
     context "when user is authenticated" do
       it "returns ok" do
-        patient = create(:patient)
-        headers = auth_token_for(create(:user))
+        patient = create(:patient, user: user)
+        headers = auth_token_for(user)
 
         delete "/api/v1/patients/#{patient.id}", headers: headers
 
@@ -206,9 +210,9 @@ RSpec.describe "Patients" do
 
       context "when patient cannot be destroyed" do
         it "returns unprocessable_content" do
-          patient = create(:patient)
+          patient = create(:patient, user: user)
           create(:event_procedure, patient:)
-          headers = auth_token_for(create(:user))
+          headers = auth_token_for(user)
 
           delete "/api/v1/patients/#{patient.id}", headers: headers
 
@@ -216,9 +220,9 @@ RSpec.describe "Patients" do
         end
 
         it "returns errors" do
-          patient = create(:patient)
+          patient = create(:patient, user: user)
           create(:event_procedure, patient:)
-          headers = auth_token_for(create(:user))
+          headers = auth_token_for(user)
 
           delete "/api/v1/patients/#{patient.id}", headers: headers
 

--- a/spec/requests/api/v1/procedures_request_spec.rb
+++ b/spec/requests/api/v1/procedures_request_spec.rb
@@ -163,6 +163,7 @@ RSpec.describe "Procedures" do
         headers = auth_token_for(create(:user))
         delete "/api/v1/procedures/#{procedure.id}", headers: headers
 
+        expect(response.parsed_body[:message]).to eq("#{procedure.class} deleted successfully.")
         expect(response).to have_http_status(:ok)
       end
 

--- a/spec/requests/api/v1/procedures_request_spec.rb
+++ b/spec/requests/api/v1/procedures_request_spec.rb
@@ -105,14 +105,16 @@ RSpec.describe "Procedures" do
   end
 
   describe "PUT /api/v1/procedures/:id" do
+    let(:user) { create(:user) }
+
     context "when user is authenticated" do
       context "with valid attributes" do
         it "returns ok" do
-          procedure = create(:procedure)
+          procedure = create(:procedure, user: user)
 
           params = { name: "New Procedure Name", amount_cents: 1000 }
 
-          headers = auth_token_for(create(:user))
+          headers = auth_token_for(user)
           put "/api/v1/procedures/#{procedure.id}", params: params, headers: headers
 
           expect(response).to have_http_status(:ok)
@@ -121,18 +123,18 @@ RSpec.describe "Procedures" do
 
       context "with invalid attributes" do
         it "returns unprocessable_content" do
-          procedure = create(:procedure)
+          procedure = create(:procedure, user: user)
 
-          headers = auth_token_for(create(:user))
+          headers = auth_token_for(user)
           put "/api/v1/procedures/#{procedure.id}", params: { name: nil }, headers: headers
 
           expect(response).to have_http_status(:unprocessable_content)
         end
 
         it "returns error messages" do
-          procedure = create(:procedure)
+          procedure = create(:procedure, user: user)
 
-          headers = auth_token_for(create(:user))
+          headers = auth_token_for(user)
           put "/api/v1/procedures/#{procedure.id}", params: { name: nil }, headers: headers
 
           expect(response.parsed_body.symbolize_keys).to include(
@@ -156,11 +158,13 @@ RSpec.describe "Procedures" do
   end
 
   describe "DELETE /api/v1/procedures/:id" do
+    let(:user) { create(:user) }
+
     context "when user is authenticated" do
       it "returns ok" do
-        procedure = create(:procedure)
+        procedure = create(:procedure, user: user)
 
-        headers = auth_token_for(create(:user))
+        headers = auth_token_for(user)
         delete "/api/v1/procedures/#{procedure.id}", headers: headers
 
         expect(response.parsed_body[:message]).to eq("#{procedure.class} deleted successfully.")
@@ -169,24 +173,24 @@ RSpec.describe "Procedures" do
 
       context "when procedure cannot be destroyed" do
         it "returns unprocessable_content" do
-          procedure = create(:procedure)
+          procedure = create(:procedure, user: user)
 
           allow(Procedure).to receive(:find).with(procedure.id.to_s).and_return(procedure)
           allow(procedure).to receive(:destroy).and_return(false)
 
-          headers = auth_token_for(create(:user))
+          headers = auth_token_for(user)
           delete "/api/v1/procedures/#{procedure.id}", headers: headers
 
           expect(response).to have_http_status(:unprocessable_content)
         end
 
         it "returns error messages" do
-          procedure = create(:procedure)
+          procedure = create(:procedure, user: user)
 
           allow(Procedure).to receive(:find).with(procedure.id.to_s).and_return(procedure)
           allow(procedure).to receive(:destroy).and_return(false)
 
-          headers = auth_token_for(create(:user))
+          headers = auth_token_for(user)
           delete "/api/v1/procedures/#{procedure.id}", headers: headers
 
           expect(response.parsed_body).to eq("cannot_destroy")

--- a/spec/support/pundit.rb
+++ b/spec/support/pundit.rb
@@ -1,0 +1,1 @@
+require "pundit/rspec"

--- a/spec/support/pundit.rb
+++ b/spec/support/pundit.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require "pundit/rspec"


### PR DESCRIPTION
## Changes
- Change success message to delete endpoints and fix tests
- Add owner in policies to procedure_policy and patient_policy
  - Obs.:
    - There are 4 policies that need owner to update and delete endpoint: event_procedures_policy, medical_shifts_policy, procedures_policy, patients_policy. The models don't belong to user, so they can check `user == record.user`.
    -  3 policies that don't have delete endpoint: event_procedure_dashboard_policy, health_insurance_policy, user_policy.
    - Hospital_policy have delete action, but the models don't belong to user, so we can't check `user == record.user`.
- Add tests to all policies