### PR TITLE
Fixes the HealthInsurence#index to return true and false custom values.

### DIFF
--- a/app/operations/health_insurances/list.rb
+++ b/app/operations/health_insurances/list.rb
@@ -23,7 +23,7 @@ module HealthInsurances
       if %w[true false].include?(params[:custom])
         query.by_custom(custom: params[:custom], user: user)
       else
-        query.where(custom: false)
+        query.where(user: user)
       end
     end
   end


### PR DESCRIPTION
Closes #234 
Fixes the return of `apply_custom_filter` method when no `custom` parameter  is passed.
