### PR TITLE
Fixes HealthInsurance endpoint to return custom and not custom values.

### DIFF
--- a/app/operations/health_insurances/list.rb
+++ b/app/operations/health_insurances/list.rb
@@ -23,7 +23,7 @@ module HealthInsurances
       if %w[true false].include?(params[:custom])
         query.by_custom(custom: params[:custom], user: user)
       else
-        query.where(user: user)
+        query.where(user: [user, nil])
       end
     end
   end

--- a/spec/requests/api/v1/health_insurances_request_spec.rb
+++ b/spec/requests/api/v1/health_insurances_request_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "HealthInsurances" do
         let!(:user) { create(:user) }
         let(:health_insurance_custom) { create(:health_insurance, custom: true, user: user) }
         let!(:health_insurance_not_custom) { create(:health_insurance, custom: false, user: user) }
-        let(:health_insurance_default) { create(:health_insurance, custom: false, user: nil) }
+        let!(:health_insurance_default) { create(:health_insurance, custom: false, user: nil) }
 
         before do
           headers = auth_token_for(user)
@@ -89,12 +89,18 @@ RSpec.describe "HealthInsurances" do
         end
 
         it "returns health_insurances" do
-          expect(response.parsed_body[0]).to eq(
+          expect(response.parsed_body).to include(
             {
               "id" => health_insurance_not_custom.id,
               "name" => health_insurance_not_custom.name,
               "custom" => false,
               "user_id" => user.id
+            },
+            {
+              "id" => health_insurance_default.id,
+              "name" => health_insurance_default.name,
+              "custom" => false,
+              "user_id" => nil
             }
           )
         end

--- a/spec/requests/api/v1/health_insurances_request_spec.rb
+++ b/spec/requests/api/v1/health_insurances_request_spec.rb
@@ -44,6 +44,102 @@ RSpec.describe "HealthInsurances" do
         end
       end
 
+      context "when Custom param is true" do
+        let!(:user) { create(:user) }
+        let!(:health_insurance_custom) { create(:health_insurance, custom: true, user: user) }
+        let(:health_insurance_not_custom) { create(:health_insurance, custom: false, user: user) }
+        let(:health_insurance_default) { create(:health_insurance, custom: false, user: nil) }
+
+        before do
+          headers = auth_token_for(user)
+          params = { custom: true }
+          get "/api/v1/health_insurances", headers: headers, params: params
+        end
+
+        it "returns ok" do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "returns health_insurances" do
+          expect(response.parsed_body[0]).to eq(
+            {
+              "id" => health_insurance_custom.id,
+              "name" => health_insurance_custom.name,
+              "custom" => true,
+              "user_id" => user.id
+            }
+          )
+        end
+      end
+
+      context "when Custom param is false" do
+        let!(:user) { create(:user) }
+        let(:health_insurance_custom) { create(:health_insurance, custom: true, user: user) }
+        let!(:health_insurance_not_custom) { create(:health_insurance, custom: false, user: user) }
+        let(:health_insurance_default) { create(:health_insurance, custom: false, user: nil) }
+
+        before do
+          headers = auth_token_for(user)
+          params = { custom: false }
+          get "/api/v1/health_insurances", headers: headers, params: params
+        end
+
+        it "returns ok" do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "returns health_insurances" do
+          expect(response.parsed_body[0]).to eq(
+            {
+              "id" => health_insurance_not_custom.id,
+              "name" => health_insurance_not_custom.name,
+              "custom" => false,
+              "user_id" => user.id
+            }
+          )
+        end
+      end
+
+      context "when Custom param is missing" do
+        let!(:user) { create(:user) }
+        let!(:health_insurance_custom) { create(:health_insurance, custom: true, user: user) }
+        let!(:health_insurance_not_custom) { create(:health_insurance, custom: false, user: user) }
+        let!(:health_insurance_default) { create(:health_insurance, custom: false, user: nil) }
+
+        before do
+          headers = auth_token_for(user)
+          params = {}
+          get "/api/v1/health_insurances", headers: headers, params: params
+        end
+
+        it "returns ok" do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "returns health_insurances" do
+          expect(response.parsed_body).to include(
+            {
+              "id" => health_insurance_custom.id,
+              "name" => health_insurance_custom.name,
+              "custom" => true,
+              "user_id" => user.id
+            },
+            {
+              "id" => health_insurance_not_custom.id,
+              "name" => health_insurance_not_custom.name,
+              "custom" => false,
+              "user_id" => user.id
+            },
+            {
+              "id" => health_insurance_default.id,
+              "name" => health_insurance_default.name,
+              "custom" => false,
+              "user_id" => nil
+            }
+          )
+        end
+      end
+
       context "when there are no health insurances" do
         before do
           headers = auth_token_for(create(:user))


### PR DESCRIPTION
- **Description**
Fixes HealthInsurance endpoint to return custom, not custom and seed health insurances when no Custom param is passed.
Closes #241 