### PR TITLE
Adds default value for Urgency on EventProcedures table

### DIFF
--- a/db/migrate/20250317144016_add_default_value_to_event_procedures_urgency.rb
+++ b/db/migrate/20250317144016_add_default_value_to_event_procedures_urgency.rb
@@ -1,0 +1,5 @@
+class AddDefaultValueToEventProceduresUrgency < ActiveRecord::Migration[7.1]
+  def change
+    change_column_default :event_procedures, :urgency, from: nil, to: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_04_173936) do
+ActiveRecord::Schema[7.1].define(version: 2025_03_17_144016) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -57,7 +57,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_04_173936) do
     t.bigint "health_insurance_id", null: false
     t.string "patient_service_number", null: false
     t.datetime "date", null: false
-    t.boolean "urgency"
+    t.boolean "urgency", default: false
     t.string "room_type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/operations/event_procedures/create_spec.rb
+++ b/spec/operations/event_procedures/create_spec.rb
@@ -256,7 +256,8 @@ RSpec.describe EventProcedures::Create, type: :operation do
         attributes = {
           patient_attributes: { id: patient.id },
           procedure_attributes: { id: procedure.id },
-          health_insurance_attributes: { id: health_insurance.id }
+          health_insurance_attributes: { id: health_insurance.id },
+          urgency: nil
         }
         result = described_class.result(attributes: attributes, user_id: user.id)
 
@@ -280,7 +281,8 @@ RSpec.describe EventProcedures::Create, type: :operation do
           attributes = {
             patient_attributes: { id: nil },
             procedure_attributes: { id: procedure.id },
-            health_insurance_attributes: { id: health_insurance.id }
+            health_insurance_attributes: { id: health_insurance.id },
+            urgency: nil
           }
           result = described_class.result(attributes: attributes, user_id: user.id)
 

--- a/spec/requests/api/v1/event_procedures_request_spec.rb
+++ b/spec/requests/api/v1/event_procedures_request_spec.rb
@@ -365,7 +365,8 @@ RSpec.describe "EventProcedures" do
             params = {
               patient_attributes: { id: patient.id },
               procedure_attributes: { id: procedure.id },
-              health_insurance_attributes: { id: health_insurance.id }
+              health_insurance_attributes: { id: health_insurance.id },
+              urgency: nil
             }
             post "/api/v1/event_procedures", params: params, headers: headers
 


### PR DESCRIPTION
- **Approach**
Creates a migration to change the default value to FALSE of Urgency field on EventProcedures table.

*Obs*: Fixes Urgency specs to correctly verify invalid params on this field.