### PR TITLE
Fix event procedure total amount cents filter

### DIFF
--- a/app/operations/event_procedures/total_amount_cents.rb
+++ b/app/operations/event_procedures/total_amount_cents.rb
@@ -9,20 +9,19 @@ module EventProcedures
     output :unpaid, type: String
 
     def call
-      procedures_by_id = Procedure.where(id: event_procedures.pluck(:procedure_id)).index_by(&:id)
-
-      self.total = calculate_amount(event_procedures, procedures_by_id)
-      self.payd = calculate_amount(event_procedures.select(&:payd), procedures_by_id)
-      self.unpaid = calculate_amount(event_procedures.reject(&:payd), procedures_by_id)
+      self.total = calculate_amount(event_procedures)
+      self.payd = calculate_amount(event_procedures.select(&:payd))
+      self.unpaid = calculate_amount(event_procedures.reject(&:payd))
     end
 
     def convert_money(amount_cents)
       Money.new(amount_cents, "BRL").format
     end
 
-    def calculate_amount(filtered_event_procedures, procedures_by_id)
+    def calculate_amount(filtered_event_procedures)
       total_cents = filtered_event_procedures.sum do |event_procedure|
-        procedures_by_id[event_procedure.procedure_id]&.amount_cents.to_i
+        result = BuildTotalAmountCents.call(event_procedure: event_procedure)
+        result.total_amount_cents
       end
       convert_money(total_cents)
     end

--- a/spec/operations/event_procedures/total_amount_cents_spec.rb
+++ b/spec/operations/event_procedures/total_amount_cents_spec.rb
@@ -10,24 +10,28 @@ RSpec.describe EventProcedures::TotalAmountCents, type: :operation do
       expect(described_class.result(event_procedures: [event_procedure])).to be_success
     end
 
-    it "returns the amount_cents total, paid and unpaid of event_procedures" do
+    it "correctly calculates total, paid and unpaid amounts" do
       user = create(:user)
-      procedure_5000 = create(:procedure, amount_cents: 5000)
-      procedure_2000 = create(:procedure, amount_cents: 2000)
-      payd_amount_cents = create_list(
+      procedure_5000 = create(:procedure, amount_cents: 5000, custom: true, user: user)
+      procedure_2000 = create(:procedure, amount_cents: 2000, custom: true, user: user)
+      paid_event_procedures = create_list(
         :event_procedure, 3,
         procedure: procedure_5000,
         user: user,
-        payd: true
+        payd: true,
+        urgency: false
       )
-      unpayd_event_procedure = create_list(
+      unpaid_event_procedures = create_list(
         :event_procedure, 2,
         procedure: procedure_2000,
         user: user,
-        payd: false
+        payd: false,
+        urgency: false
       )
-      event_procedures = payd_amount_cents + unpayd_event_procedure
+
+      event_procedures = paid_event_procedures + unpaid_event_procedures
       total_amount_cents = described_class.call(event_procedures: event_procedures)
+
       expect(total_amount_cents.total).to eq("R$190.00")
       expect(total_amount_cents.payd).to eq("R$150.00")
       expect(total_amount_cents.unpaid).to eq("R$40.00")


### PR DESCRIPTION
- **Context**
Total/Paid/Unpaid values were not returning correctly for default procedures.
Total/Paid/Unpaid for default procedures were been calculating with procedures values, but it should be calculated with CbhpmProcedures and PortValues.

- **Solution**
Instead of doing the calculation for Total/Paid/Unpaid values on TotalAmountCents, use BuildTotalAmountCents, because its calcutales the values using CbhpmProcedures and PortValues.