### PR TITLE
test: add shared context for unauthenticated access

### DIFF
--- a/spec/requests/api/v1/event_procedures_dashboard_request_spec.rb
+++ b/spec/requests/api/v1/event_procedures_dashboard_request_spec.rb
@@ -8,19 +8,9 @@ RSpec.describe "EventProcedures" do
     let(:params) { { start_date: "01/06/2000", end_date: "05/06/2000" } }
 
     describe "authentication" do
-      context "when user is not authenticated" do
-        let(:params) { {} }
-        let(:headers) { {} }
-
-        it "returns unauthorized" do
-          do_request
-          expect(response).to have_http_status(:unauthorized)
-        end
-
-        it "returns error message" do
-          do_request
-          expect(response.parsed_body["error_description"]).to eq(["Invalid token"])
-        end
+      include_context "when user is not authenticated" do
+        let(:path) { "/api/v1/event_procedures_dashboard/amount_by_day" }
+        let(:http_method) { :get }
       end
 
       context "when user is authenticated as not admin" do

--- a/spec/requests/api/v1/event_procedures_request_spec.rb
+++ b/spec/requests/api/v1/event_procedures_request_spec.rb
@@ -3,28 +3,20 @@
 require "rails_helper"
 
 RSpec.describe "EventProcedures" do
+  let!(:user) { create(:user) }
+  let(:headers) { auth_token_for(user) }
+
   describe "GET /api/v1/event_procedures" do
-    context "when user is not authenticated" do
-      it "returns unauthorized" do
-        get "/api/v1/event_procedures", params: {}, headers: {}
+    let(:path) { "/api/v1/event_procedures" }
+    let(:http_method) { :get }
+    let(:params) { {} }
 
-        expect(response).to have_http_status(:unauthorized)
-      end
-
-      it "returns error message" do
-        get "/api/v1/event_procedures"
-
-        expect(response.parsed_body["error_description"]).to eq(["Invalid token"])
-      end
-    end
+    include_context "when user is not authenticated"
 
     context "when user is authenticated" do
-      let!(:user) { create(:user) }
-
       before do
         create_list(:event_procedure, 5, user_id: user.id)
-        headers = auth_token_for(user)
-        get("/api/v1/event_procedures", params: {}, headers: headers)
+        get(path, params: {}, headers: headers)
       end
 
       it "returns ok" do
@@ -37,28 +29,22 @@ RSpec.describe "EventProcedures" do
     end
 
     context "when has filters by month" do
-      let!(:user) { create(:user) }
-
       it "returns event_procedures per month" do
-        headers = auth_token_for(user)
         create_list(:event_procedure, 3, date: "2023-02-15", user_id: user.id)
         _month_5_event_procedure = create_list(:event_procedure, 5, date: "2023-05-26", user_id: user.id)
 
-        get("/api/v1/event_procedures", params: { month: "2" }, headers: headers)
+        get(path, params: { month: "2" }, headers: headers)
 
         expect(response.parsed_body["event_procedures"].length).to eq(3)
       end
     end
 
     context "when has filters by year" do
-      let!(:user) { create(:user) }
-
       it "returns event_procedures per month" do
-        headers = auth_token_for(user)
         create_list(:event_procedure, 3, date: "2023-02-15", user_id: user.id)
         _month_5_event_procedure = create_list(:event_procedure, 5, date: "2024-05-26", user_id: user.id)
 
-        get("/api/v1/event_procedures", params: { year: "2023" }, headers: headers)
+        get(path, params: { year: "2023" }, headers: headers)
 
         expect(response.parsed_body["event_procedures"].length).to eq(3)
       end
@@ -66,28 +52,22 @@ RSpec.describe "EventProcedures" do
 
     context "when filtering by payd" do
       context "when payd is 'true'" do
-        let!(:user) { create(:user) }
-
         it "returns only paid event_procedures" do
-          headers = auth_token_for(user)
           create_list(:event_procedure, 3, payd: true, user_id: user.id)
           _unpayd_event_procedures = create_list(:event_procedure, 5, payd: false, user_id: user.id)
 
-          get("/api/v1/event_procedures", params: { payd: "true" }, headers: headers)
+          get(path, params: { payd: "true" }, headers: headers)
 
           expect(response.parsed_body["event_procedures"].length).to eq(3)
         end
       end
 
       context "when payd is 'false'" do
-        let!(:user) { create(:user) }
-
         it "returns only unpaid event_procedures" do
-          headers = auth_token_for(user)
           create_list(:event_procedure, 3, payd: true, user_id: user.id)
           _unpayd_event_procedures = create_list(:event_procedure, 5, payd: false, user_id: user.id)
 
-          get("/api/v1/event_procedures", params: { payd: "false" }, headers: headers)
+          get(path, params: { payd: "false" }, headers: headers)
 
           expect(response.parsed_body["event_procedures"].length).to eq(5)
         end
@@ -96,15 +76,13 @@ RSpec.describe "EventProcedures" do
 
     context "when has filters by hospital name" do
       it "returns event_procedures per hospital name" do
-        user = create(:user)
-        header_token = auth_token_for(user)
         hospital_cariri = create(:hospital, name: "Hospital de Cariri")
         hospital_sao_matheus = create(:hospital, name: "Hospital São Matheus")
         create(:event_procedure, hospital: hospital_cariri, user_id: user.id)
         create(:event_procedure, hospital: hospital_sao_matheus, user_id: user.id)
         hospital_params = { hospital: { name: "Hospital de Cariri" } }
 
-        get "/api/v1/event_procedures", headers: header_token, params: hospital_params
+        get path, headers: headers, params: hospital_params
 
         expect(response.parsed_body["event_procedures"].length).to eq(1)
         expect(response.parsed_body["event_procedures"].first["hospital"]).to eq("Hospital de Cariri")
@@ -113,15 +91,13 @@ RSpec.describe "EventProcedures" do
 
     context "when has filters by health_insurance name" do
       it "returns event_procedures per health_insurance name" do
-        user = create(:user)
-        header_token = auth_token_for(user)
         amil = create(:health_insurance, name: "Amil")
         unimed = create(:health_insurance, name: "Unimed")
         create(:event_procedure, health_insurance: amil, user_id: user.id)
         create(:event_procedure, health_insurance: unimed, user_id: user.id)
         health_insurance_params = { health_insurance: { name: "Unimed" } }
 
-        get "/api/v1/event_procedures", headers: header_token, params: health_insurance_params
+        get path, headers: headers, params: health_insurance_params
 
         expect(response.parsed_body["event_procedures"].length).to eq(1)
         expect(response.parsed_body["event_procedures"].first["health_insurance"]).to eq("Unimed")
@@ -129,12 +105,9 @@ RSpec.describe "EventProcedures" do
     end
 
     context "when has pagination via page and per_page" do
-      let!(:user) { create(:user) }
-
       before do
-        headers = auth_token_for(user)
         create_list(:event_procedure, 8, user_id: user.id)
-        get "/api/v1/event_procedures", params: { page: 2, per_page: 5 }, headers: headers
+        get path, params: { page: 2, per_page: 5 }, headers: headers
       end
 
       it "returns only 3 event_procedures" do
@@ -144,11 +117,13 @@ RSpec.describe "EventProcedures" do
   end
 
   describe "POST /api/v1/event_procedures" do
+    let(:path) { "/api/v1/event_procedures" }
+    let(:http_method) { :post }
+
     context "when user is authenticated" do
       context "with valid attributes" do
         context "when patient exists" do
           it "returns created" do
-            user = create(:user)
             cbhpm = create(:cbhpm)
             procedure = create(:procedure)
             create(:cbhpm_procedure, procedure: procedure, cbhpm: cbhpm, anesthetic_port: "1A")
@@ -167,14 +142,12 @@ RSpec.describe "EventProcedures" do
               health_insurance_attributes: { id: create(:health_insurance).id }
             }
 
-            headers = auth_token_for(user)
-            post "/api/v1/event_procedures", params: params, headers: headers
+            post path, params: params, headers: headers
 
             expect(response).to have_http_status(:created)
           end
 
           it "returns event_procedure" do
-            user = create(:user)
             patient = create(:patient)
             procedure = create(:procedure, amount_cents: 20_000, description: "nice description")
             cbhpm = create(:cbhpm)
@@ -196,8 +169,7 @@ RSpec.describe "EventProcedures" do
               cbhpm_id: cbhpm.id
             }
 
-            headers = auth_token_for(user)
-            post "/api/v1/event_procedures", params: params, headers: headers
+            post path, params: params, headers: headers
 
             expect(response.parsed_body).to include(
               "procedure" => EventProcedure.last.procedure.name,
@@ -218,7 +190,6 @@ RSpec.describe "EventProcedures" do
 
         context "when patient does not exist" do
           it "returns created" do
-            user = create(:user)
             procedure = create(:procedure)
             health_insurance = create(:health_insurance)
             cbhpm = create(:cbhpm)
@@ -239,14 +210,12 @@ RSpec.describe "EventProcedures" do
               health_insurance_attributes: { id: health_insurance.id }
             }
 
-            headers = auth_token_for(user)
-            post "/api/v1/event_procedures", params: params, headers: headers
+            post path, params: params, headers: headers
 
             expect(response).to have_http_status(:created)
           end
 
           it "returns event_procedure" do
-            user = create(:user)
             procedure = create(:procedure)
             cbhpm = create(:cbhpm)
             create(:cbhpm_procedure, procedure: procedure, cbhpm: cbhpm, anesthetic_port: "1A")
@@ -266,8 +235,7 @@ RSpec.describe "EventProcedures" do
               health_insurance_attributes: { id: health_insurance.id }
             }
 
-            headers = auth_token_for(user)
-            post "/api/v1/event_procedures", params: params, headers: headers
+            post path, params: params, headers: headers
 
             expect(response.parsed_body).to include(
               "procedure" => EventProcedure.last.procedure.name,
@@ -285,7 +253,6 @@ RSpec.describe "EventProcedures" do
 
         context "when procedure does not exist" do
           it "returns created" do
-            user = create(:user)
             patient = create(:patient)
             health_insurance = create(:health_insurance)
             cbhpm = create(:cbhpm)
@@ -305,8 +272,7 @@ RSpec.describe "EventProcedures" do
               health_insurance_attributes: { id: health_insurance.id }
             }
 
-            headers = auth_token_for(user)
-            post "/api/v1/event_procedures", params: params, headers: headers
+            post path, params: params, headers: headers
 
             expect(response).to have_http_status(:created)
           end
@@ -314,7 +280,6 @@ RSpec.describe "EventProcedures" do
 
         context "when health_insurance does not exist" do
           it "returns created" do
-            user = create(:user)
             patient = create(:patient)
             procedure = create(:procedure)
             cbhpm = create(:cbhpm)
@@ -335,8 +300,7 @@ RSpec.describe "EventProcedures" do
               health_insurance_attributes: health_insurance_attributes
             }
 
-            headers = auth_token_for(user)
-            post "/api/v1/event_procedures", params: params, headers: headers
+            post path, params: params, headers: headers
 
             expect(response).to have_http_status(:created)
           end
@@ -346,19 +310,17 @@ RSpec.describe "EventProcedures" do
       context "with invalid attributes" do
         context "when patient_id and patient_name are nil" do
           it "returns unprocessable_content" do
-            headers = auth_token_for(create(:user))
             params = {
               patient_attributes: { id: nil },
               procedure_attributes: { id: nil },
               health_insurance_attributes: { id: nil }
             }
-            post "/api/v1/event_procedures", params: params, headers: headers
+            post path, params: params, headers: headers
 
             expect(response).to have_http_status(:unprocessable_content)
           end
 
           it "returns error message" do
-            headers = auth_token_for(create(:user))
             patient = create(:patient)
             procedure = create(:procedure)
             health_insurance = create(:health_insurance)
@@ -367,7 +329,7 @@ RSpec.describe "EventProcedures" do
               procedure_attributes: { id: procedure.id },
               health_insurance_attributes: { id: health_insurance.id }
             }
-            post "/api/v1/event_procedures", params: params, headers: headers
+            post path, params: params, headers: headers
 
             expect(response.parsed_body).to eq(
               "cbhpm" => ["must exist"],
@@ -382,16 +344,10 @@ RSpec.describe "EventProcedures" do
       end
     end
 
-    context "when user is not authenticated" do
-      it "returns unauthorized" do
-        health_insurance = create(:health_insurance)
-        procedure = create(:procedure)
-        cbhpm = create(:cbhpm)
-        create(:cbhpm_procedure, procedure: procedure, cbhpm: cbhpm, anesthetic_port: "1A")
-        create(:port_value, cbhpm: cbhpm, anesthetic_port: "1A", amount_cents: 1000)
-        patient = create(:patient)
-        params = {
-
+    include_context "when user is not authenticated" do
+      let(:health_insurance) { create(:health_insurance) }
+      let(:params) do
+        {
           hospital_id: create(:hospital).id,
           patient_service_number: "1234567890",
           date: Time.zone.now.to_date,
@@ -403,19 +359,25 @@ RSpec.describe "EventProcedures" do
           procedure_attributes: { id: procedure.id },
           health_insurance_attributes: { id: health_insurance.id }
         }
+      end
+      let(:procedure) { create(:procedure) }
+      let(:cbhpm) { create(:cbhpm) }
+      let(:patient) { create(:patient) }
 
-        post "/api/v1/event_procedures", params: params, headers: {}
-
-        expect(response).to have_http_status(:unauthorized)
+      before do
+        create(:cbhpm_procedure, procedure: procedure, cbhpm: cbhpm, anesthetic_port: "1A")
+        create(:port_value, cbhpm: cbhpm, anesthetic_port: "1A", amount_cents: 1000)
       end
     end
   end
 
   describe "PUT /api/v1/event_procedures/:id" do
+    let(:path) { "/api/v1/event_procedures/#{event_procedure.id}" }
+    let(:http_method) { :put }
+
     context "when user is authenticated" do
       context "with valid attributes and the record belongs to the user" do
         it "returns ok" do
-          user = create(:user)
           health_insurance = create(:health_insurance)
           procedure = create(:procedure)
           cbhpm = create(:cbhpm)
@@ -445,14 +407,12 @@ RSpec.describe "EventProcedures" do
             health_insurance_attributes: { id: health_insurance.id }
           }
 
-          headers = auth_token_for(user)
           put "/api/v1/event_procedures/#{event_procedure.id}", params: params, headers: headers
 
           expect(response).to have_http_status(:ok)
         end
 
         it "updates event_procedure" do
-          user = create(:user)
           health_insurance = create(:health_insurance)
           procedure = create(:procedure, name: "Angioplastia transluminal")
           patient = create(:patient)
@@ -473,7 +433,6 @@ RSpec.describe "EventProcedures" do
             urgency: true
           }
 
-          headers = auth_token_for(user)
           put "/api/v1/event_procedures/#{event_procedure.id}", params: params, headers: headers
 
           expect(event_procedure.reload.urgency).to be true
@@ -484,7 +443,6 @@ RSpec.describe "EventProcedures" do
 
       context "with valid attributes and the record not belongs to the user" do
         it "returns unauthorized" do
-          user = create(:user)
           health_insurance = create(:health_insurance)
           procedure = create(:procedure)
           cbhpm = create(:cbhpm)
@@ -513,7 +471,6 @@ RSpec.describe "EventProcedures" do
             health_insurance_attributes: { id: health_insurance.id }
           }
 
-          headers = auth_token_for(user)
           put "/api/v1/event_procedures/#{event_procedure.id}", params: params, headers: headers
 
           expect(response).to have_http_status(:unauthorized)
@@ -522,7 +479,6 @@ RSpec.describe "EventProcedures" do
 
       context "with invalid attributes" do
         it "returns unprocessable_content" do
-          user = create(:user)
           health_insurance = create(:health_insurance)
           procedure = create(:procedure)
           cbhpm = create(:cbhpm)
@@ -538,14 +494,12 @@ RSpec.describe "EventProcedures" do
             user_id: user.id
           )
 
-          headers = auth_token_for(user)
           put "/api/v1/event_procedures/#{event_procedure.id}", params: { date: nil }, headers: headers
 
           expect(response).to have_http_status(:unprocessable_content)
         end
 
         it "returns error message" do
-          user = create(:user)
           health_insurance = create(:health_insurance)
           procedure = create(:procedure)
           cbhpm = create(:cbhpm)
@@ -561,7 +515,6 @@ RSpec.describe "EventProcedures" do
             user_id: user.id
           )
 
-          headers = auth_token_for(user)
           put "/api/v1/event_procedures/#{event_procedure.id}", params: { date: nil }, headers: headers
 
           expect(response.parsed_body).to eq(["Date can't be blank"])
@@ -569,12 +522,11 @@ RSpec.describe "EventProcedures" do
       end
     end
 
-    context "when user is not authenticated" do
-      it "returns unauthorized" do
-        user = create(:user)
-        event_procedure = create(:event_procedure, user_id: user.id)
+    include_context "when user is not authenticated" do
+      let(:event_procedure) { create(:event_procedure, user_id: user.id) }
 
-        params = {
+      let(:params) do
+        {
           procedure_id: create(:procedure).id,
           patient_id: create(:patient).id,
           hospital_id: create(:hospital).id,
@@ -585,21 +537,19 @@ RSpec.describe "EventProcedures" do
           room_type: EventProcedures::RoomTypes::WARD,
           payment: EventProcedures::Payments::HEALTH_INSURANCE
         }
-
-        put "/api/v1/event_procedures/#{event_procedure.id}", params: params, headers: {}
-
-        expect(response).to have_http_status(:unauthorized)
       end
     end
   end
 
   describe "DELETE /api/v1/event_procedures/:id" do
+    let(:path) { "/api/v1/event_procedures/#{event_procedure.id}" }
+    let(:http_method) { :delete }
+    let(:params) { {} }
+
     context "when user is authenticated" do
       it "returns ok" do
-        user = create(:user)
         event_procedure = create(:event_procedure, user_id: user.id)
 
-        headers = auth_token_for(user)
         delete "/api/v1/event_procedures/#{event_procedure.id}", headers: headers
 
         expect(response.parsed_body[:message]).to eq("#{event_procedure.class} deleted successfully.")
@@ -608,26 +558,22 @@ RSpec.describe "EventProcedures" do
 
       context "when event_procedure cannot be destroyed" do
         it "returns unprocessable_content" do
-          user = create(:user)
           event_procedure = create(:event_procedure, user_id: user.id)
 
           allow(EventProcedure).to receive(:find).with(event_procedure.id.to_s).and_return(event_procedure)
           allow(event_procedure).to receive(:destroy).and_return(false)
 
-          headers = auth_token_for(user)
           delete "/api/v1/event_procedures/#{event_procedure.id}", headers: headers
 
           expect(response).to have_http_status(:unprocessable_content)
         end
 
         it "returns error message" do
-          user = create(:user)
           event_procedure = create(:event_procedure, user_id: user.id)
 
           allow(EventProcedure).to receive(:find).with(event_procedure.id.to_s).and_return(event_procedure)
           allow(event_procedure).to receive(:destroy).and_return(false)
 
-          headers = auth_token_for(user)
           delete "/api/v1/event_procedures/#{event_procedure.id}", headers: headers
 
           expect(response.parsed_body).to eq("cannot_destroy")
@@ -635,14 +581,8 @@ RSpec.describe "EventProcedures" do
       end
     end
 
-    context "when user is not authenticated" do
-      it "returns unauthorized" do
-        event_procedure = create(:event_procedure)
-
-        delete "/api/v1/event_procedures/#{event_procedure.id}", headers: {}
-
-        expect(response).to have_http_status(:unauthorized)
-      end
+    include_context "when user is not authenticated" do
+      let(:event_procedure) { create(:event_procedure) }
     end
   end
 end

--- a/spec/requests/api/v1/health_insurances_request_spec.rb
+++ b/spec/requests/api/v1/health_insurances_request_spec.rb
@@ -3,23 +3,21 @@
 require "rails_helper"
 
 RSpec.describe "HealthInsurances" do
-  describe "GET /api/v1/health_insurances" do
-    context "when user is not authenticated" do
-      it "returns unauthorized status" do
-        get "/api/v1/health_insurances"
+  let!(:user) { create(:user) }
+  let(:headers) { auth_token_for(user) }
 
-        expect(response).to have_http_status(:unauthorized)
-      end
-    end
+  describe "GET /api/v1/health_insurances" do
+    let(:path) { "/api/v1/health_insurances" }
+    let(:http_method) { :get }
+    let(:params) { {} }
 
     context "when user is authenticated" do
       context "when there are health insurances" do
         let!(:health_insurances) { create_list(:health_insurance, 2) }
 
         before do
-          headers = auth_token_for(create(:user))
           params = { custom: false }
-          get "/api/v1/health_insurances", headers: headers, params: params
+          get path, headers: headers, params: params
         end
 
         it "returns ok" do
@@ -45,13 +43,11 @@ RSpec.describe "HealthInsurances" do
       end
 
       context "when Custom param is true" do
-        let!(:user) { create(:user) }
         let!(:health_insurance_custom) { create(:health_insurance, custom: true, user: user) }
         let(:health_insurance_not_custom) { create(:health_insurance, custom: false, user: user) }
         let(:health_insurance_default) { create(:health_insurance, custom: false, user: nil) }
 
         before do
-          headers = auth_token_for(user)
           params = { custom: true }
           get "/api/v1/health_insurances", headers: headers, params: params
         end
@@ -73,13 +69,11 @@ RSpec.describe "HealthInsurances" do
       end
 
       context "when Custom param is false" do
-        let!(:user) { create(:user) }
         let(:health_insurance_custom) { create(:health_insurance, custom: true, user: user) }
         let!(:health_insurance_not_custom) { create(:health_insurance, custom: false, user: user) }
         let!(:health_insurance_default) { create(:health_insurance, custom: false, user: nil) }
 
         before do
-          headers = auth_token_for(user)
           params = { custom: false }
           get "/api/v1/health_insurances", headers: headers, params: params
         end
@@ -107,15 +101,13 @@ RSpec.describe "HealthInsurances" do
       end
 
       context "when Custom param is missing" do
-        let!(:user) { create(:user) }
         let!(:health_insurance_custom) { create(:health_insurance, custom: true, user: user) }
         let!(:health_insurance_not_custom) { create(:health_insurance, custom: false, user: user) }
         let!(:health_insurance_default) { create(:health_insurance, custom: false, user: nil) }
 
         before do
-          headers = auth_token_for(user)
           params = {}
-          get "/api/v1/health_insurances", headers: headers, params: params
+          get path, headers: headers, params: params
         end
 
         it "returns ok" do
@@ -148,8 +140,7 @@ RSpec.describe "HealthInsurances" do
 
       context "when there are no health insurances" do
         before do
-          headers = auth_token_for(create(:user))
-          get "/api/v1/health_insurances", headers: headers
+          get path, headers: headers
         end
 
         it "returns ok" do
@@ -164,8 +155,7 @@ RSpec.describe "HealthInsurances" do
       context "when has pagination via page and per_page" do
         before do
           create_list(:health_insurance, 8)
-          headers = auth_token_for(create(:user))
-          get "/api/v1/health_insurances", params: { page: 2, per_page: 5, custom: false }, headers: headers
+          get path, params: { page: 2, per_page: 5, custom: false }, headers: headers
         end
 
         it "returns only 3 health_insurances" do
@@ -173,24 +163,23 @@ RSpec.describe "HealthInsurances" do
         end
       end
     end
+
+    include_context "when user is not authenticated"
   end
 
   describe "POST /api/v1/health_insurances" do
-    context "when user is not authenticated" do
-      it "returns unauthorized status" do
-        post "/api/v1/health_insurances"
+    let(:path) { "/api/v1/health_insurances" }
+    let(:http_method) { :post }
+    let(:params) { {} }
 
-        expect(response).to have_http_status(:unauthorized)
-      end
-    end
+    include_context "when user is not authenticated"
 
     context "when user is authenticated" do
       context "when params are valid" do
         let(:health_insurance_params) { attributes_for(:health_insurance) }
 
         before do
-          headers = auth_token_for(create(:user))
-          post "/api/v1/health_insurances", params: health_insurance_params, headers: headers
+          post path, params: health_insurance_params, headers: headers
         end
 
         it "returns created" do
@@ -209,7 +198,6 @@ RSpec.describe "HealthInsurances" do
         let(:health_insurance_params) { { name: nil } }
 
         before do
-          headers = auth_token_for(create(:user))
           post "/api/v1/health_insurances", params: health_insurance_params, headers: headers
         end
 

--- a/spec/requests/api/v1/hello_word_request_spec.rb
+++ b/spec/requests/api/v1/hello_word_request_spec.rb
@@ -17,20 +17,11 @@ RSpec.describe "HelloWorlds" do
 
   describe "GET /api/v1/private_method" do
     let(:user) { create(:user) }
+    let(:path) { "/api/v1/private_method" }
+    let(:http_method) { :get }
+    let(:params) { {} }
 
-    context "when user is not authenticated" do
-      before do
-        get "/api/v1/private_method"
-      end
-
-      it "renders json with message" do
-        expect(response.body).to include("error", "Invalid token")
-      end
-
-      it "receives http status unauthorized" do
-        expect(response).to have_http_status(:unauthorized)
-      end
-    end
+    include_context "when user is not authenticated"
 
     context "when user is authenticated" do
       let(:instance_token) { Devise::Api::TokensService::Create.new(resource_owner: user, previous_refresh_token: nil) }

--- a/spec/requests/api/v1/pdf_reports_request_spec.rb
+++ b/spec/requests/api/v1/pdf_reports_request_spec.rb
@@ -4,11 +4,13 @@ require "rails_helper"
 
 RSpec.describe "PdfReports" do
   describe "GET api/v1/pdf_reports/generate" do
+    let(:user) { create(:user) }
+    let(:headers) { auth_token_for(user) }
+    let(:path) { api_v1_pdf_reports_generate_path }
+
     context "when entity_name is missing" do
       it "returns a bad request error" do
-        user = create(:user)
-        headers = auth_token_for(user)
-        get api_v1_pdf_reports_generate_path, headers: headers
+        get path, headers: headers
 
         expect(response).to have_http_status(:bad_request)
         expect(response.parsed_body["error"]).to eq("You must inform the `entity_name` parameter")
@@ -17,10 +19,8 @@ RSpec.describe "PdfReports" do
 
     context "when entity_name is 'event_procedures'" do
       before do
-        user = create(:user)
-        headers = auth_token_for(user)
         entity_name = "event_procedures"
-        get api_v1_pdf_reports_generate_path, params: { entity_name: entity_name }, headers: headers
+        get path, params: { entity_name: entity_name }, headers: headers
       end
 
       it "returns a PDF file" do
@@ -38,10 +38,8 @@ RSpec.describe "PdfReports" do
 
     context "when entity_name is 'medical_shifts'" do
       before do
-        user = create(:user)
-        headers = auth_token_for(user)
         entity_name = "medical_shifts"
-        get api_v1_pdf_reports_generate_path, params: { entity_name: entity_name }, headers: headers
+        get path, params: { entity_name: entity_name }, headers: headers
       end
 
       it "returns a PDF file" do

--- a/spec/requests/api/v1/users_request_spec.rb
+++ b/spec/requests/api/v1/users_request_spec.rb
@@ -4,15 +4,16 @@ require "rails_helper"
 
 RSpec.describe "Users" do
   describe "GET /api/v1/users" do
-    context "when user authenticated" do
-      let(:token) { api_token(user) }
+    let(:token) { api_token(user) }
+    let(:path) { "/api/v1/users" }
+    let(:headers) { auth_token_for(user) }
 
+    context "when user authenticated" do
       context "when user is authorized" do
         let!(:user) { create(:user, admin: true) }
 
         context "when data is valid" do
           before do
-            headers = auth_token_for(user)
             get "/api/v1/users", params: {}, headers: headers
           end
 
@@ -38,11 +39,10 @@ RSpec.describe "Users" do
       end
 
       context "when user is unauthorized" do
-        let!(:user) { create(:user) }
+        let(:user) { create(:user) }
 
         before do
-          headers = auth_token_for(user)
-          get "/api/v1/users", params: {}, headers: headers
+          get path, params: {}, headers: headers
         end
 
         it { expect(response).to have_http_status(:unauthorized) }
@@ -56,7 +56,7 @@ RSpec.describe "Users" do
     context "when user unauthenticated" do
       context "when has user" do
         before do
-          get "/api/v1/users"
+          get path
         end
 
         it { expect(response).to have_http_status(:unauthorized) }

--- a/spec/support/shared_contexts/unauthenticated_user.rb
+++ b/spec/support/shared_contexts/unauthenticated_user.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.shared_context "when user is not authenticated" do
+  before do
+    send(http_method, path, params: params, headers: {})
+  end
+
+  it "returns unauthorized" do
+    expect(response).to have_http_status(:unauthorized)
+  end
+
+  it "returns error message" do
+    expect(response.parsed_body["error_description"]).to eq(["Invalid token"])
+  end
+end


### PR DESCRIPTION
This task introduces a 'shared context' for handling unauthenticated user requests in request tests. Instead of repeating the same authentication failure checks, we now reuse the shared context across multiple tests,  for this was created shared_context 'when user is not authenticated'`.

fix #220 