### PR TITLE
Fixes total value on EventProcedure to return values without consider pages and per_page params

### DIFF
--- a/app/controllers/api/v1/event_procedures_controller.rb
+++ b/app/controllers/api/v1/event_procedures_controller.rb
@@ -8,12 +8,14 @@ module Api
 
       def index
         authorized_scope = policy_scope(EventProcedure)
-        event_procedures = EventProcedures::List.result(
+        listed_event_procedures = EventProcedures::List.result(
           scope: authorized_scope,
           params: event_procedure_permitted_query_params
-        ).event_procedures
+        )
+        event_procedures = listed_event_procedures.event_procedures
+        event_procedures_unpaginated = listed_event_procedures.event_procedures_unpaginated
 
-        total_amount_cents = EventProcedures::TotalAmountCents.call(event_procedures: event_procedures)
+        total_amount_cents = EventProcedures::TotalAmountCents.call(event_procedures: event_procedures_unpaginated)
 
         render json: {
           total: total_amount_cents.total,

--- a/app/operations/event_procedures/list.rb
+++ b/app/operations/event_procedures/list.rb
@@ -6,9 +6,11 @@ module EventProcedures
     input :params, type: Hash, default: -> { {} }
 
     output :event_procedures, type: Enumerable
+    output :event_procedures_unpaginated, type: Enumerable
 
     def call
-      self.event_procedures = filtered_query.order(date: :desc).page(params[:page]).per(params[:per_page])
+      self.event_procedures_unpaginated = filtered_query.order(date: :desc)
+      self.event_procedures = event_procedures_unpaginated.page(params[:page]).per(params[:per_page])
     end
 
     private

--- a/spec/operations/event_procedures/list_spec.rb
+++ b/spec/operations/event_procedures/list_spec.rb
@@ -103,5 +103,22 @@ RSpec.describe EventProcedures::List, type: :operation do
 
       it { expect(result.event_procedures).to eq [EventProcedure.last] }
     end
+
+    describe "event_procedures_unpaginated" do
+      context "when there are event procedures outside of pagination" do
+        let!(:event_procedures) { create_list(:event_procedure, 11) }
+
+        it "returns all event procedures" do
+          result = described_class.result(
+            scope: EventProcedure.all,
+            params: { page: "1", per_page: "5" }
+          )
+          event_procedures_paginated = result.event_procedures
+          event_procedures_unpaginated = result.event_procedures_unpaginated
+          expect(event_procedures_unpaginated).to match_array(event_procedures)
+          expect(event_procedures_paginated.count).to eq(5)
+        end
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/event_procedures_request_spec.rb
+++ b/spec/requests/api/v1/event_procedures_request_spec.rb
@@ -106,12 +106,17 @@ RSpec.describe "EventProcedures" do
 
     context "when has pagination via page and per_page" do
       before do
-        create_list(:event_procedure, 8, user_id: user.id)
+        procedure = create(:procedure, custom: true, user: user, amount_cents: 5000)
+        create_list(:event_procedure, 8, user_id: user.id, total_amount_cents: 5000, procedure: procedure)
         get path, params: { page: 2, per_page: 5 }, headers: headers
       end
 
       it "returns only 3 event_procedures" do
         expect(response.parsed_body["event_procedures"].length).to eq(3)
+      end
+
+      it "returns total values without consider page and per_page params" do
+        expect(response.parsed_body["total"]).to eq("R$400.00")
       end
     end
   end


### PR DESCRIPTION
- *Context*
Total/Paind/Unpaid values was considering the page param on the returning values.
