### PR TITLE
Fixes deprecation warning for Rails.application.secrets

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -310,4 +310,6 @@ Devise.setup do |config|
   config.api.configure do |api|
     api.access_token.expires_in = 1.month
   end
+
+  config.secret_key = Rails.application.secret_key_base
 end


### PR DESCRIPTION
Fix #260 

- *Context*
Devise is currently trying to find a secret key in credentials, secrets and config before checking the application itself, deprecation warning is triggered on every call to Rails.application.secrets.

- *Solution*
Configure Devise's secret_key on setup.

https://github.com/heartcombo/devise/issues/5644