### PR TITLE
Upgrade devise version from 4.9.2 to 4.9.4 to remove deprecation warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem "bootsnap", "1.18.3", require: false
 # gem "image_processing", "~> 1.2"
 
 # Devise is a flexible authentication solution for Rails based on Warden [https://github.com/heartcombo/devise]
-gem "devise", "4.9.2"
+gem "devise", "4.9.4"
 # devise-api authenticate API requests [https://github.com/nejdetkadir/devise-api]
 gem "devise-api", github: "nejdetkadir/devise-api", branch: "main"
 # Enumerations for Ruby with some magic powers!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,7 +145,7 @@ GEM
     debug (1.9.2)
       irb (~> 1.10)
       reline (>= 0.3.8)
-    devise (4.9.2)
+    devise (4.9.4)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0)
@@ -573,7 +573,7 @@ DEPENDENCIES
   brakeman (= 6.1.2)
   capybara (= 3.40.0)
   debug (= 1.9.2)
-  devise (= 4.9.2)
+  devise (= 4.9.4)
   devise-api!
   dotenv-rails (= 3.1.2)
   enumerate_it (= 4.0.0)


### PR DESCRIPTION
Fixes #261 

- *Context*
Warning generated: `DEPRECATION WARNING: DeprecatedConstantAccessor.deprecate_constant without a deprecator is deprecated`.

Devise shouldn't be using the DeprecatedConstantAccessor anymore, and instead should be using the Devise.deprecator which does not generate a Deprecation Warning. Described in https://github.com/heartcombo/devise/issues/5635

It was fixed on devise 4.9.3
https://github.com/heartcombo/devise/blob/v4.9.4/CHANGELOG.md#494---2024-04-10

- *Solution*
Upgrade Devise version to 4.9.4 (latest version)