### PR TITLE
Removes 'version' from docker-compose.yml to avoid warning

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 x-app: &app
   build:
     context: .


### PR DESCRIPTION
Fix #262 

- *Context*
Warning generated: `WARN[0000] /home/ferreira/Repositories/med_system_backend/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion`.

- *Solution*
Remove `version` attribute from docker-compose.yml.