### PR TITLE
Fixes user login redirection for admins and no admins

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,19 @@
 
 class ApplicationController < ActionController::Base
   before_action :set_paper_trail_whodunnit
+
+  protected
+
+  def after_sign_in_path_for(resource)
+    stored_location_for(resource) ||
+      if resource.admin?
+        admin_health_insurances_path
+      else
+        api_v1_event_procedures_path
+      end
+  end
+
+  def after_sign_up_path_for(resource)
+    after_sign_in_path_for(resource)
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,8 @@
   </head>
 
   <body>
+    <p class = "notice"><%= notice%></p>
+    <p class = "alert"><%= alert%></p>
     <%= yield %>
   </body>
 </html>


### PR DESCRIPTION
_Description_

- Fixed the login flow for users.
- Now after login, the user is redirected based on their role (admin or non-admin).
- Error messages are displayed correctly when login fails.

_Changes_

- Overridden after_sign_in_path_for method.


fix #211 