### PR TITLE
Enable Devise Recoverable for Users

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -65,4 +65,6 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
+
+  config.action_controller.allow_forgery_protection = true
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -45,4 +45,37 @@ RSpec.describe User do
       expect(user).to be_active_for_authentication
     end
   end
+
+  describe "password reset" do
+    let(:user) { create(:user, email: "test@email.com") }
+
+    before do
+      user.confirm
+    end
+
+    it "sends password reset email" do
+      expect { user.send_reset_password_instructions }.to change { ActionMailer::Base.deliveries.count }.by(1)
+    end
+
+    it "generates reset password token" do
+      expect(user.reset_password_token).to be_nil
+      user.send_reset_password_instructions
+      expect(user.reset_password_token).not_to be_nil
+    end
+
+    it "resets password" do
+      user.send_reset_password_instructions
+      new_password = "new_secure_password"
+      user.reset_password(new_password, new_password)
+      expect(user.valid_password?(new_password)).to be(true)
+    end
+
+    it "clears reset password token after password reset" do
+      user.send_reset_password_instructions
+      expect(user.reset_password_token).not_to be_nil
+      new_password = "new_secure_password"
+      user.reset_password(new_password, new_password)
+      expect(user.reset_password_token).to be_nil
+    end
+  end
 end

--- a/spec/requests/api/v1/users_request_spec.rb
+++ b/spec/requests/api/v1/users_request_spec.rb
@@ -67,4 +67,37 @@ RSpec.describe "Users" do
       end
     end
   end
+
+  describe "Password recovery" do
+    subject(:get_new_password) { get "/users/password/new" }
+
+    let(:user) { create(:user, email: "email@email.com") }
+    let(:headers) { auth_token_for(user) }
+
+    it "returns ok" do
+      get_new_password
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "contains reset token" do
+      get_new_password
+      token = response.parsed_body.css('input[name="authenticity_token"]').first["value"]
+      expect(token).not_to be_nil
+    end
+
+    it "sends reset instructions" do
+      get_new_password
+
+      auth_token = response.parsed_body.css('input[name="authenticity_token"]').first["value"]
+
+      post "/users/password",
+        headers: headers,
+        params: {
+          authenticity_token: auth_token,
+          user: { email: user.email }
+        }
+
+      expect { user.reload }.to change(user, :reset_password_token)
+    end
+  end
 end


### PR DESCRIPTION
Fix #292 

- *Context*
Enable Devise module Recoverable for Users.

- *Solution*
**Obs**: Recoverable module was enabled already.
Add specs for Recoverable.