### PR TITLE
feat: gem sidekiq-failures added to improve job failure visualization

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,8 @@ gem "sentry-ruby", "5.17.3"
 gem "service_actor", "3.7.0"
 # Simple, efficient background processing for Ruby [https://github.com/sidekiq/sidekiq]
 gem "sidekiq", "7.2.4"
+# Middleware to track failed Sidekiq jobs [https://github.com/mhfs/sidekiq-failures]
+gem "sidekiq-failures", git: "https://github.com/mhfs/sidekiq-failures", branch: "master"
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem "sprockets-rails", "3.5.1"
 # A sampling call-stack profiler for ruby 2.2+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,12 @@
 GIT
+  remote: https://github.com/mhfs/sidekiq-failures
+  revision: a99e7d1905651ca98a4ad56c2842df66fbbc3797
+  branch: master
+  specs:
+    sidekiq-failures (1.0.4)
+      sidekiq (>= 4.0.0)
+
+GIT
   remote: https://github.com/nejdetkadir/devise-api.git
   revision: 006bddee4bbe9f5ff9edc936d54725ce061be720
   branch: main
@@ -635,6 +643,7 @@ DEPENDENCIES
   service_actor (= 3.7.0)
   shoulda-matchers (= 5.3.0)
   sidekiq (= 7.2.4)
+  sidekiq-failures!
   simplecov (= 0.22.0)
   spring (= 4.2.1)
   spring-commands-rspec (= 1.0.4)

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -5,6 +5,11 @@ sidekiq_config = { url: ENV["REDIS_URL"] || "redis://localhost:6379/0" }
 Sidekiq.configure_server do |config|
   config.logger.level = Logger::ERROR
   config.redis = sidekiq_config
+
+  config.failures_max_count = 5000
+  config.server_middleware do |chain|
+    chain.add Sidekiq::Failures::Middleware
+  end
 end
 
 Sidekiq.configure_client do |config|


### PR DESCRIPTION
`sidekiq-failures` gem added to improve visualization of failed jobs in the Sidekiq dashboard.

fix #308 