### PR TITLE
Configs Devise module Lockable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@
 !.env.example
 
 lib/data/procedures/
+
+/.idea

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,8 @@ class User < ApplicationRecord
   # :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
     :recoverable, :rememberable, :validatable, :api,
-    :omniauthable, :confirmable, omniauth_providers: %i[github strava]
+    :omniauthable, :confirmable, :lockable,
+    omniauth_providers: %i[github strava]
 
   has_many :event_procedures, dependent: :destroy
   has_many :medical_shifts, dependent: :destroy

--- a/db/migrate/20250528125806_add_lockable_to_users.rb
+++ b/db/migrate/20250528125806_add_lockable_to_users.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddLockableToUsers < ActiveRecord::Migration[7.1]
+  def change
+    change_table :users, bulk: true do |t|
+      t.integer :failed_attempts
+      t.string :unlock_token
+      t.datetime :locked_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_05_12_172117) do
+ActiveRecord::Schema[7.1].define(version: 2025_05_28_125806) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -167,6 +167,9 @@ ActiveRecord::Schema[7.1].define(version: 2025_05_12_172117) do
     t.text "confirmation_token"
     t.text "unconfirmed_email"
     t.datetime "deleted_at"
+    t.integer "failed_attempts"
+    t.string "unlock_token"
+    t.datetime "locked_at"
     t.index ["deleted_at"], name: "index_users_on_deleted_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
Fix #283 

- *Solution*
Enables Lockable Devise module.
Creates migration to add lockable required fields.