### PR TITLE
Fix to query n+1 in eventprocedure

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -117,7 +117,7 @@ group :development do
   gem "rubocop-rspec_rails", "!= 2.29.0", require: false
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console", "4.2.1"
-
+  gem "bullet"
   gem "brakeman", "6.1.2"
 
   # Preview mail in the browser instead of sending.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,6 +133,9 @@ GEM
     brakeman (6.1.2)
       racc
     builder (3.3.0)
+    bullet (8.0.8)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     capybara (3.40.0)
       addressable
       matrix
@@ -577,6 +580,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
+    uniform_notifier (1.17.0)
     uri (0.13.2)
     version_gem (1.1.4)
     warden (1.2.9)
@@ -606,6 +610,7 @@ DEPENDENCIES
   administrate (= 0.20.1)
   bootsnap (= 1.18.3)
   brakeman (= 6.1.2)
+  bullet
   capybara (= 3.40.0)
   debug (= 1.9.2)
   devise (= 4.9.4)

--- a/app/controllers/api/v1/event_procedures_controller.rb
+++ b/app/controllers/api/v1/event_procedures_controller.rb
@@ -6,24 +6,28 @@ module Api
       after_action :verify_authorized, except: :index
       after_action :verify_policy_scoped, only: :index
 
-      def index
-        authorized_scope = policy_scope(EventProcedure)
-        listed_event_procedures = EventProcedures::List.result(
-          scope: authorized_scope,
-          params: event_procedure_permitted_query_params
-        )
-        event_procedures = listed_event_procedures.event_procedures
-        event_procedures_unpaginated = listed_event_procedures.event_procedures_unpaginated
+    def index
+      authorized_scope = policy_scope(EventProcedure)
 
-        total_amount_cents = EventProcedures::TotalAmountCents.call(event_procedures: event_procedures_unpaginated)
+      listed_event_procedures = EventProcedures::List.result(
+        scope:  authorized_scope,
+        params: event_procedure_permitted_query_params
+      )
 
-        render json: {
-          total: total_amount_cents.total,
-          total_paid: total_amount_cents.paid,
-          total_unpaid: total_amount_cents.unpaid,
-          event_procedures: serialized_event_procedures(event_procedures)
-        }, status: :ok
-      end
+      event_procedures              = listed_event_procedures.event_procedures
+      event_procedures_unpaginated  = listed_event_procedures.event_procedures_unpaginated
+
+      total_amount_cents = EventProcedures::TotalAmountCents.call(
+        event_procedures: event_procedures_unpaginated
+      )
+
+      render json: {
+        total:        total_amount_cents.total,
+        total_paid:   total_amount_cents.paid,
+        total_unpaid: total_amount_cents.unpaid,
+        event_procedures: serialized_event_procedures(event_procedures)
+      }, status: :ok
+    end
 
       def create
         authorize(EventProcedure)

--- a/app/models/event_procedure.rb
+++ b/app/models/event_procedure.rb
@@ -6,6 +6,8 @@ class EventProcedure < ApplicationRecord
   has_enumeration_for :room_type, with: EventProcedures::RoomTypes, create_helpers: true
   has_enumeration_for :payment, with: EventProcedures::Payments, create_helpers: true
 
+  has_many :port_values, through: :cbhpm
+
   monetize :total_amount
 
   belongs_to :cbhpm

--- a/app/operations/event_procedures/list.rb
+++ b/app/operations/event_procedures/list.rb
@@ -16,7 +16,13 @@ module EventProcedures
     private
 
     def filtered_query
-      query = scope.includes(%i[procedure patient hospital health_insurance])
+      query = scope.includes(
+        :procedure,
+        :patient,
+        :hospital,
+        :health_insurance,
+        cbhpm: :port_values
+      )
       apply_all_filters(query)
     end
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -64,6 +64,14 @@ Rails.application.configure do
   # Suppress logger output for asset requests.
   config.assets.quiet = true
 
+  # The Bullet gem helps detect N+1 queries and other inefficiencies in ActiveRecord queries.
+  config.after_initialize do
+    Bullet.enable        = true
+    Bullet.alert         = true
+    Bullet.bullet_logger = true
+    Bullet.console       = true
+  end
+
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
 

--- a/spec/factories/event_procedures.rb
+++ b/spec/factories/event_procedures.rb
@@ -37,5 +37,11 @@ FactoryBot.define do
         event_procedure.health_insurance = build(:health_insurance, evaluator.health_insurance_attributes)
       end
     end
+
+    trait :with_port_values do
+      after(:create) do |ep|
+        create_list(:port_value, 2, cbhpm: ep.cbhpm)
+      end
+    end
   end
 end

--- a/spec/support/query_helper.rb
+++ b/spec/support/query_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module QueryHelper
+  def count_queries(&block)
+    queries = []
+    callback = ->(_name, _start, _finish, _id, payload) do
+      queries << payload[:sql] unless payload[:name] =~ /SCHEMA|TRANSACTION/
+    end
+
+    ActiveSupport::Notifications.subscribed(callback, "sql.active_record", &block)
+    queries.count
+  end
+end


### PR DESCRIPTION
_Context_
- The index action of the EventProceduresController controller was generating an N+1 query when accessing the port_values association through cbhpm.

_Solution_
- The port_values association has been added to the EventProcedures::List service. This means the association is loaded along with the others (procedure, patient, hospital, health_insurance) in a single query, avoiding the N+1 problem.


Fix #325 